### PR TITLE
Re-network onboarding [2/X]

### DIFF
--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ActivityHelper.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ActivityHelper.kt
@@ -7,8 +7,8 @@ import android.view.View
 import android.widget.Toast
 import com.cornellappdev.coffee_chats_android.models.ApiResponse
 import com.cornellappdev.coffee_chats_android.models.UserField.Category
-import com.cornellappdev.coffee_chats_android.networking.*
-import com.google.gson.reflect.TypeToken
+import com.cornellappdev.coffee_chats_android.networking.updateGroups
+import com.cornellappdev.coffee_chats_android.networking.updateInterests
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -42,6 +42,7 @@ fun increaseHitArea(view: View, padding: Int = 100) {
 interface OnFilledOutListener {
     /** Actions to be taken when all required fields are filled out */
     fun onFilledOut()
+
     /** Actions to be taken when not all required fields are filled out */
     fun onSelectionEmpty()
 }
@@ -52,6 +53,7 @@ interface OnFilledOutListener {
 interface OnFilledOutObservable {
     /** Passes the observable the listener needs to notify when status of fields changes */
     fun setOnFilledOutListener(callback: OnFilledOutListener)
+
     /** Saves user-entered information in the current fragment on the backend */
     fun saveInformation()
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ActivityHelper.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ActivityHelper.kt
@@ -61,20 +61,14 @@ interface OnFilledOutObservable {
  * if `isInterest` is true, and groups otherwise. An error message is displayed via a Toast if an
  * error occurs.
  */
-fun updateUserField(applicationContext: Context, items: List<String>, category: Category) {
+fun updateUserField(applicationContext: Context, items: List<Int>, category: Category) {
     CoroutineScope(Dispatchers.Main).launch {
-        val updateEndpoint = when (category) {
-            Category.INTEREST -> Endpoint.updateInterests(items)
-            Category.GROUP -> Endpoint.updateGroups(items)
-            Category.GOAL -> Endpoint.updateGoals(items)
-            Category.TALKING_POINT -> Endpoint.updateTalkingPoints(items)
-        }
-        val typeToken = object : TypeToken<ApiResponse<String>>() {}.type
         val updateResponse = withContext(Dispatchers.IO) {
-            Request.makeRequest<ApiResponse<String>>(
-                updateEndpoint.okHttpRequest(),
-                typeToken
-            )
+            when (category) {
+                Category.INTEREST -> updateInterests(items)
+                Category.GROUP -> updateGroups(items)
+                Category.GOAL -> ApiResponse(true, null, null) // TODO after goals get ids
+            }
         }
         if (updateResponse == null || !updateResponse.success) {
             Toast.makeText(applicationContext, "Failed to save information", Toast.LENGTH_LONG)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
@@ -235,10 +235,6 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
     }
 
     override fun saveInformation() {
-        updateUserField(
-            requireContext(),
-            selectedItems.map { item -> item.getText() },
-            if (isInterest) UserField.Category.INTEREST else UserField.Category.GROUP
-        )
+        TODO("Implement updated networking call")
     }
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/OnboardingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/OnboardingActivity.kt
@@ -10,24 +10,19 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
-import com.cornellappdev.coffee_chats_android.models.ApiResponse
 import com.cornellappdev.coffee_chats_android.models.User
 import com.cornellappdev.coffee_chats_android.models.UserField
 import com.cornellappdev.coffee_chats_android.models.UserSession
-import com.cornellappdev.coffee_chats_android.networking.Endpoint
-import com.cornellappdev.coffee_chats_android.networking.Request
-import com.cornellappdev.coffee_chats_android.networking.getSelfProfile
 import com.cornellappdev.coffee_chats_android.networking.getUser
-import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.activity_onboarding.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class OnboardingActivity : AppCompatActivity(), OnFilledOutListener,
     PromptsFragment.PromptsContainer {
 
+    // TODO Figure out if this is necessary - fetching user from backend in every fragment maintains consistency
     /** Current user profile- will be mutated as user fills out information in onboarding */
     private lateinit var user: User
 
@@ -42,13 +37,12 @@ class OnboardingActivity : AppCompatActivity(), OnFilledOutListener,
             Content.GROUPS,
             Content.PROMPTS,
             Content.GOALS,
-            Content.TALKING_POINTS,
             Content.SOCIAL_MEDIA
         )
 
     /** Pages that display the Add Later button */
     private val addLaterPages =
-        listOf(Content.GROUPS, Content.GOALS, Content.TALKING_POINTS, Content.SOCIAL_MEDIA)
+        listOf(Content.GROUPS, Content.GOALS, Content.SOCIAL_MEDIA)
 
     /** All onboarding pages */
     enum class Content {
@@ -57,7 +51,6 @@ class OnboardingActivity : AppCompatActivity(), OnFilledOutListener,
         GROUPS,
         PROMPTS,
         GOALS,
-        TALKING_POINTS,
         SOCIAL_MEDIA
     }
 
@@ -169,7 +162,6 @@ class OnboardingActivity : AppCompatActivity(), OnFilledOutListener,
                 Content.GROUPS -> UserFieldFragment.newInstance(UserField.Category.GROUP)
                 Content.PROMPTS -> PromptsFragment()
                 Content.GOALS -> UserFieldFragment.newInstance(UserField.Category.GOAL)
-                Content.TALKING_POINTS -> UserFieldFragment.newInstance(UserField.Category.TALKING_POINT)
                 Content.SOCIAL_MEDIA -> SocialMediaFragment()
             }
             val ft: FragmentTransaction = supportFragmentManager.beginTransaction()
@@ -190,7 +182,6 @@ class OnboardingActivity : AppCompatActivity(), OnFilledOutListener,
             Content.GROUPS -> getString(R.string.groups_header)
             Content.PROMPTS -> getString(R.string.prompts_header)
             Content.GOALS -> getString(R.string.goals_header)
-            Content.TALKING_POINTS -> getString(R.string.talking_pointers_header)
             Content.SOCIAL_MEDIA -> getString(R.string.social_media_header)
         }
         back_button.visibility = if (content == Content.CREATE_PROFILE) View.GONE else View.VISIBLE

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -16,7 +16,8 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
 import com.cornellappdev.coffee_chats_android.models.User
-import com.cornellappdev.coffee_chats_android.networking.*
+import com.cornellappdev.coffee_chats_android.networking.getUser
+import com.cornellappdev.coffee_chats_android.networking.setUpNetworking
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.material.navigation.NavigationView
 import kotlinx.android.synthetic.main.activity_scheduling.*

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -103,7 +103,10 @@ class SchedulingActivity :
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        setUpDrawerLayout()
+        CoroutineScope(Dispatchers.Main).launch {
+            user = getUser()
+            setUpDrawerLayout()
+        }
     }
 
     /**

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SocialMediaFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SocialMediaFragment.kt
@@ -11,10 +11,7 @@ import androidx.fragment.app.Fragment
 import com.cornellappdev.coffee_chats_android.models.ApiResponse
 import com.cornellappdev.coffee_chats_android.models.Location
 import com.cornellappdev.coffee_chats_android.models.SocialMedia
-import com.cornellappdev.coffee_chats_android.networking.Endpoint
-import com.cornellappdev.coffee_chats_android.networking.Request
-import com.cornellappdev.coffee_chats_android.networking.getUserSocialMedia
-import com.cornellappdev.coffee_chats_android.networking.updateSocialMedia
+import com.cornellappdev.coffee_chats_android.networking.*
 import com.google.gson.reflect.TypeToken
 import kotlinx.android.synthetic.main.fragment_social_media.*
 import kotlinx.coroutines.CoroutineScope
@@ -34,14 +31,7 @@ class SocialMediaFragment : Fragment(), OnFilledOutObservable {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         callback!!.onSelectionEmpty()
         CoroutineScope(Dispatchers.Main).launch {
-            val getUserSocialMediaEndpoint = Endpoint.getUserSocialMedia()
-            val typeToken = object : TypeToken<ApiResponse<SocialMedia>>() {}.type
-            val userSocialMedia = withContext(Dispatchers.IO) {
-                Request.makeRequest<ApiResponse<SocialMedia>>(
-                    getUserSocialMediaEndpoint.okHttpRequest(),
-                    typeToken
-                )
-            }!!.data
+            val user = getUser()
             val textWatcher = object : TextWatcher {
                 override fun afterTextChanged(s: Editable) {}
 
@@ -53,8 +43,8 @@ class SocialMediaFragment : Fragment(), OnFilledOutObservable {
             }
             instagramEditText.addTextChangedListener(textWatcher)
             facebookEditText.addTextChangedListener(textWatcher)
-            instagramEditText.setText(userSocialMedia!!.instagram)
-            facebookEditText.setText(userSocialMedia!!.facebook)
+            instagramEditText.setText(user.instagramUsername)
+            facebookEditText.setText(user.facebookUrl)
         }
     }
 
@@ -75,14 +65,7 @@ class SocialMediaFragment : Fragment(), OnFilledOutObservable {
     override fun saveInformation() {
         val socialMedia = SocialMedia(facebookEditText.text.toString().trim(), instagramEditText.text.toString().trim())
         CoroutineScope(Dispatchers.Main).launch {
-            val updateSocialMediaEndpoint = Endpoint.updateSocialMedia(socialMedia)
-            val typeToken = object : TypeToken<ApiResponse<SocialMedia>>() {}.type
-            val updateSocialMediaResponse = withContext(Dispatchers.IO) {
-                Request.makeRequest<ApiResponse<List<Location>>>(
-                    updateSocialMediaEndpoint.okHttpRequest(),
-                    typeToken
-                )
-            }
+            val updateSocialMediaResponse = updateSocialMedia(socialMedia)
             if (updateSocialMediaResponse == null || !updateSocialMediaResponse.success) {
                 Toast.makeText(requireContext(), "Failed to save information", Toast.LENGTH_LONG)
                     .show()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SocialMediaFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SocialMediaFragment.kt
@@ -8,16 +8,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
-import com.cornellappdev.coffee_chats_android.models.ApiResponse
-import com.cornellappdev.coffee_chats_android.models.Location
 import com.cornellappdev.coffee_chats_android.models.SocialMedia
-import com.cornellappdev.coffee_chats_android.networking.*
-import com.google.gson.reflect.TypeToken
+import com.cornellappdev.coffee_chats_android.networking.getUser
+import com.cornellappdev.coffee_chats_android.networking.updateSocialMedia
 import kotlinx.android.synthetic.main.fragment_social_media.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class SocialMediaFragment : Fragment(), OnFilledOutObservable {
 
@@ -35,7 +32,13 @@ class SocialMediaFragment : Fragment(), OnFilledOutObservable {
             val textWatcher = object : TextWatcher {
                 override fun afterTextChanged(s: Editable) {}
 
-                override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+                override fun beforeTextChanged(
+                    s: CharSequence,
+                    start: Int,
+                    count: Int,
+                    after: Int
+                ) {
+                }
 
                 override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                     toggleSaveButton()
@@ -63,7 +66,10 @@ class SocialMediaFragment : Fragment(), OnFilledOutObservable {
     }
 
     override fun saveInformation() {
-        val socialMedia = SocialMedia(facebookEditText.text.toString().trim(), instagramEditText.text.toString().trim())
+        val socialMedia = SocialMedia(
+            facebookEditText.text.toString().trim(),
+            instagramEditText.text.toString().trim()
+        )
         CoroutineScope(Dispatchers.Main).launch {
             val updateSocialMediaResponse = updateSocialMedia(socialMedia)
             if (updateSocialMediaResponse == null || !updateSocialMediaResponse.success) {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
@@ -28,18 +28,12 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
 
     private lateinit var category: Category
 
-    /** pages that have a search bar */
-    private val searchableContent = listOf(Category.GROUP, Category.TALKING_POINT)
+    /** pages that have a search bar - kept as a list to facilitate adding searchable fragments */
+    private val searchableContent = listOf(Category.GROUP)
 
     lateinit var adapter: UserFieldAdapter
     private lateinit var fieldAdapterArray: Array<UserField>
     private lateinit var currFieldAdapterArray: Array<UserField>
-
-    /** master list of all valid options for this field */
-    private lateinit var fieldTitles: Array<String>
-
-    /** master list of all subtitles for this field */
-    private lateinit var fieldSubtitles: Array<String>
 
     /** fields selected by the user */
     private lateinit var userFields: ArrayList<String>
@@ -64,34 +58,18 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         CoroutineScope(Dispatchers.Main).launch {
             // initialize lateinit vars
-            when (category) {
+            fieldAdapterArray = when (category) {
                 Category.INTEREST -> {
-                    getAllInterests().let { allInterestsList ->
-                        fieldTitles = allInterestsList.map { it.name }.toTypedArray()
-                        fieldSubtitles = allInterestsList.map { it.subtitle }.toTypedArray()
-                    }
-                }
-                Category.TALKING_POINT -> {
-                    getAllInterests().let { allInterestsList ->
-                        fieldTitles = allInterestsList.map { it.name }.toTypedArray()
-                        fieldSubtitles = allInterestsList.map { it.subtitle }.toTypedArray()
-                    }
-                    getAllGroups().let { allGroupsList ->
-                        fieldTitles += allGroupsList.map { it.name }.toTypedArray()
-                        fieldSubtitles += Array(allGroupsList.size) { "" }
-                    }
+                    getAllInterests().map { UserField(it.name, it.subtitle, null, it.id) }
                 }
                 Category.GOAL -> {
-                    fieldTitles = resources.getStringArray(R.array.goal_titles)
-                    fieldSubtitles = Array(fieldTitles.size) { "" }
+                    resources.getStringArray(R.array.goal_titles)
+                        .map { UserField(it, "", null, -1) }
                 }
                 Category.GROUP -> {
-                    getAllGroups().let { allGroupsList ->
-                        fieldTitles += allGroupsList.map { it.name }.toTypedArray()
-                        fieldSubtitles += Array(allGroupsList.size) { "" }
-                    }
+                    getAllGroups().map { UserField(it.name, "", null, it.id) }
                 }
-            }
+            }.toTypedArray()
 
             selectedColor = ContextCompat.getColor(requireContext(), R.color.onboardingListSelected)
             unselectedColor = ContextCompat.getColor(requireContext(), R.color.onboarding_fields)
@@ -101,43 +79,22 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
 
             val user = getUser()
             // fetch fields already selected by user
+            // TODO- refactor to only store IDs?
             userFields = ArrayList(
                 when (category) {
-                    Category.INTEREST -> user.interests
-                    Category.GROUP -> user.groups
+                    Category.INTEREST -> user.interests.map { it.name }
+                    Category.GROUP -> user.groups.map { it.name }
                     Category.GOAL -> if (user.goals.isNullOrEmpty()) emptyList() else user.goals
-                    Category.TALKING_POINT -> if (user.talkingPoints.isNullOrEmpty()) emptyList() else user.talkingPoints
                 }
             )
             // set up adapter
-            fieldAdapterArray = Array(fieldTitles.size) { UserField() }
-            val resources = requireContext().resources
-            val packageName = requireContext().packageName
-            for (i in fieldTitles.indices) {
-                fieldAdapterArray[i] = UserField(
-                    fieldTitles[i],
-                    if (i < fieldSubtitles.size) fieldSubtitles[i] else "",
-                    null
-//                    when (category) {
-//                        Category.INTEREST -> {
-//                            resources.getIdentifier(
-//                                "ic_int_${fieldTitles[i].split(" ")[0].toLowerCase()}",
-//                                "drawable",
-//                                packageName
-//                            )
-//                        }
-//                        Category.GROUP -> if (fieldTitles[i] == "Cornell AppDev") R.drawable.ic_gr_appdev_logo else R.drawable.groups_white
-//                        else -> null
-//                    }
-                )
-            }
             fieldAdapterArray.sortBy { u -> u.getText() }
             adapter =
                 UserFieldAdapter(
                     requireContext(),
                     fieldAdapterArray.toList(),
                     UserFieldAdapter.ItemColor.TOGGLE,
-                    category in listOf(Category.GOAL, Category.TALKING_POINT)
+                    true // TODO- display icons
                 )
             interests_or_groups.adapter = adapter
             // display selected fields
@@ -208,7 +165,7 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
                             requireContext(),
                             currFieldAdapterArray.toList(),
                             UserFieldAdapter.ItemColor.TOGGLE,
-                            category in listOf(Category.GOAL, Category.TALKING_POINT)
+                            category == Category.GOAL
                         )
                     interests_or_groups.adapter = adapter
                     for (i in currFieldAdapterArray.indices) {
@@ -236,7 +193,7 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
     }
 
     override fun saveInformation() {
-        val items = userFields
+        val items = userFields.map { userField -> fieldAdapterArray.first { it.getText() == userField }.id }
         if (category in searchableContent) {
             group_search.setQuery("", false)
         }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
@@ -193,7 +193,8 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
     }
 
     override fun saveInformation() {
-        val items = userFields.map { userField -> fieldAdapterArray.first { it.getText() == userField }.id }
+        val items =
+            userFields.map { userField -> fieldAdapterArray.first { it.getText() == userField }.id }
         if (category in searchableContent) {
             group_search.setQuery("", false)
         }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/SocialMedia.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/SocialMedia.kt
@@ -1,3 +1,12 @@
 package com.cornellappdev.coffee_chats_android.models
 
-data class SocialMedia(val facebook: String, val instagram: String, val didOnboard: Boolean = true)
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class SocialMedia(
+    @Json(name = "facebook_url")
+    val facebookUrl: String?,
+    @Json(name = "instagram_username")
+    val instagramUsername: String?
+)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
@@ -1,4 +1,5 @@
 package com.cornellappdev.coffee_chats_android.models
+
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
@@ -27,8 +27,8 @@ data class User(
     val talkingPoints: List<String>?,
     val availability: List<String>?,
     val locations: List<String>,
-    val interests: List<String>,
-    val groups: List<String>,
+    val interests: List<Interest>,
+    val groups: List<Group>,
     @Json(name = "has_onboarded")
     val hasOnboarded: Boolean,
     @Json(name = "pending_feedback")

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/UserField.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/UserField.kt
@@ -1,6 +1,11 @@
 package com.cornellappdev.coffee_chats_android.models
 
-class UserField(private var text: String = "", private var subtext: String = "", val drawableId: Int? = null, val id: Int = -1) {
+class UserField(
+    private var text: String = "",
+    private var subtext: String = "",
+    val drawableId: Int? = null,
+    val id: Int = -1
+) {
     enum class Category {
         INTEREST,
         GROUP,
@@ -9,11 +14,11 @@ class UserField(private var text: String = "", private var subtext: String = "",
 
     private var selected: Boolean = false
 
-    fun getText() : String {
+    fun getText(): String {
         return text
     }
 
-    fun getSubtext() : String {
+    fun getSubtext(): String {
         return subtext
     }
 
@@ -25,7 +30,7 @@ class UserField(private var text: String = "", private var subtext: String = "",
         selected = true
     }
 
-    fun isSelected() : Boolean {
+    fun isSelected(): Boolean {
         return selected
     }
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/UserField.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/UserField.kt
@@ -1,11 +1,10 @@
 package com.cornellappdev.coffee_chats_android.models
 
-class UserField(private var text: String = "", private var subtext: String = "", val drawableId: Int? = null) {
+class UserField(private var text: String = "", private var subtext: String = "", val drawableId: Int? = null, val id: Int = -1) {
     enum class Category {
         INTEREST,
         GROUP,
-        GOAL,
-        TALKING_POINT
+        GOAL
     }
 
     private var selected: Boolean = false

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/NetworkingUtils.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/NetworkingUtils.kt
@@ -40,6 +40,15 @@ suspend fun <T> postDataHelper(endpoint: Endpoint, typeToken: Type): ApiResponse
         )
     }
 
+/** Post list data */
+suspend fun <T> postListDataHelper(endpoint: Endpoint, typeToken: Type): ApiResponse<List<T>>? =
+    withContext(Dispatchers.IO) {
+        Request.makeMoshiRequest<List<T>>(
+            endpoint.okHttpRequest(),
+            Types.newParameterizedType(List::class.java, typeToken)
+        )
+    }
+
 // AUTH
 
 suspend fun authenticateUser(idToken: String): UserSession =
@@ -61,7 +70,13 @@ suspend fun getAllMajors(): List<Major> = getListHelper(Endpoint.getAllMajors(),
 suspend fun getAllInterests(): List<Interest> =
     getListHelper(Endpoint.getAllInterests(), Interest::class.java)
 
+suspend fun updateInterests(interestIdsList: List<Int>): ApiResponse<List<Int>>? =
+    postListDataHelper(Endpoint.updateInterests(interestIdsList), Integer::class.java)
+
 // GROUPS
 
 suspend fun getAllGroups(): List<Group> =
     getListHelper(Endpoint.getAllGroups(), Group::class.java)
+
+suspend fun updateGroups(groupIdsList: List<Int>): ApiResponse<List<Int>>? =
+    postListDataHelper(Endpoint.updateGroups(groupIdsList), Integer::class.java)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/NetworkingUtils.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/NetworkingUtils.kt
@@ -80,3 +80,8 @@ suspend fun getAllGroups(): List<Group> =
 
 suspend fun updateGroups(groupIdsList: List<Int>): ApiResponse<List<Int>>? =
     postListDataHelper(Endpoint.updateGroups(groupIdsList), Integer::class.java)
+
+// SOCIAL MEDIA
+
+suspend fun updateSocialMedia(socialMedia: SocialMedia): ApiResponse<SocialMedia>? =
+    postDataHelper(Endpoint.updateSocialMedia(socialMedia), SocialMedia::class.java)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/NetworkingUtils.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/NetworkingUtils.kt
@@ -52,7 +52,10 @@ suspend fun <T> postListDataHelper(endpoint: Endpoint, typeToken: Type): ApiResp
 // AUTH
 
 suspend fun authenticateUser(idToken: String): UserSession =
-    postDataHelper<UserSession>(Endpoint.authenticateUser(idToken), UserSession::class.java)!!.data!!
+    postDataHelper<UserSession>(
+        Endpoint.authenticateUser(idToken),
+        UserSession::class.java
+    )!!.data!!
 
 // PROFILE
 

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
@@ -17,6 +17,8 @@ private val MEDIA_TYPE = ("application/json; charset=utf-8").toMediaType()
 private fun authHeader(): Map<String, String> =
     mapOf("Authorization" to "Token ${UserSession.currentAccessToken}")
 
+private val gson = Gson()
+
 private val moshi = Moshi.Builder()
     .addLast(KotlinJsonAdapterFactory())
     .build()
@@ -94,9 +96,19 @@ fun Endpoint.Companion.updateGroups(groupIdsList: List<Int>): Endpoint {
     )
 }
 
-/* OLD NETWORKING */
+// SOCIAL MEDIA
 
-private val gson = Gson()
+fun Endpoint.Companion.updateSocialMedia(socialMedia: SocialMedia): Endpoint {
+    val requestBody = toRequestBody(socialMedia, SocialMedia::class.java)
+    return Endpoint(
+        path = "/me/",
+        headers = authHeader(),
+        body = requestBody,
+        method = EndpointMethod.POST
+    )
+}
+
+/* OLD NETWORKING */
 
 private fun <K, V> mapToRequestBody(map: Map<K, V>): RequestBody =
     gson.toJson(map).toRequestBody("application/json; charset=utf-8".toMediaType())
@@ -145,20 +157,6 @@ fun Endpoint.Companion.updateLocations(locations: List<Location>): Endpoint {
     val requestBody = json.toString().toRequestBody("application/json; charset=utf-8".toMediaType())
     return Endpoint(
         path = "/user/preferredLocations",
-        headers = authHeader(),
-        body = requestBody,
-        method = EndpointMethod.POST
-    )
-}
-
-fun Endpoint.Companion.getUserSocialMedia(netID: String = ""): Endpoint =
-    getFieldHelper(netID, "socialMedia")
-
-fun Endpoint.Companion.updateSocialMedia(socialMedia: SocialMedia): Endpoint {
-    val requestBody =
-        gson.toJson(socialMedia).toRequestBody("application/json; charset=utf-8".toMediaType())
-    return Endpoint(
-        path = "/user/socialMedia",
         headers = authHeader(),
         body = requestBody,
         method = EndpointMethod.POST

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
@@ -12,6 +12,8 @@ import java.lang.reflect.Type
 
 /* NEW NETWORKING */
 
+private val MEDIA_TYPE = ("application/json; charset=utf-8").toMediaType()
+
 private fun authHeader(): Map<String, String> =
     mapOf("Authorization" to "Token ${UserSession.currentAccessToken}")
 
@@ -23,7 +25,12 @@ private val moshi = Moshi.Builder()
 private fun <T> toRequestBody(data: T, typeToken: Type): RequestBody {
     Log.d("REQUEST_BODY", moshi.adapter<T>(typeToken).toJson(data).toString())
     return moshi.adapter<T>(typeToken).toJson(data)
-        .toRequestBody(("application/json; charset=utf-8").toMediaType())
+        .toRequestBody(MEDIA_TYPE)
+}
+
+private fun toListRequestBody(key: String, data: List<Int>): RequestBody {
+    val json = gson.toJson(mapOf(key to data))
+    return json.toString().toRequestBody(MEDIA_TYPE)
 }
 
 // AUTH
@@ -61,10 +68,30 @@ fun Endpoint.Companion.getAllInterests(): Endpoint {
     return Endpoint(path = "/interests/", headers = authHeader(), method = EndpointMethod.GET)
 }
 
+fun Endpoint.Companion.updateInterests(interestIdsList: List<Int>): Endpoint {
+    val requestBody = toListRequestBody("interests", interestIdsList)
+    return Endpoint(
+        path = "/me/",
+        headers = authHeader(),
+        body = requestBody,
+        method = EndpointMethod.POST
+    )
+}
+
 // GROUPS
 
 fun Endpoint.Companion.getAllGroups(): Endpoint {
     return Endpoint(path = "/groups/", headers = authHeader(), method = EndpointMethod.GET)
+}
+
+fun Endpoint.Companion.updateGroups(groupIdsList: List<Int>): Endpoint {
+    val requestBody = toListRequestBody("groups", groupIdsList)
+    return Endpoint(
+        path = "/me/",
+        headers = authHeader(),
+        body = requestBody,
+        method = EndpointMethod.POST
+    )
 }
 
 /* OLD NETWORKING */
@@ -95,28 +122,6 @@ fun Endpoint.Companion.getUserInterests(netID: String = ""): Endpoint =
     getFieldHelper(netID, "interests")
 
 fun Endpoint.Companion.getUserGroups(netID: String = ""): Endpoint = getFieldHelper(netID, "groups")
-
-fun Endpoint.Companion.updateInterests(interests: List<String>): Endpoint {
-    val json = gson.toJson(mapOf("interests" to interests))
-    val requestBody = json.toString().toRequestBody("application/json; charset=utf-8".toMediaType())
-    return Endpoint(
-        path = "/user/interests",
-        headers = authHeader(),
-        body = requestBody,
-        method = EndpointMethod.POST
-    )
-}
-
-fun Endpoint.Companion.updateGroups(groups: List<String>): Endpoint {
-    val json = gson.toJson(mapOf("groups" to groups))
-    val requestBody = json.toString().toRequestBody("application/json; charset=utf-8".toMediaType())
-    return Endpoint(
-        path = "/user/groups",
-        headers = authHeader(),
-        body = requestBody,
-        method = EndpointMethod.POST
-    )
-}
 
 fun Endpoint.Companion.getUserAvailabilities(netID: String = ""): Endpoint =
     getFieldHelper(netID, "availabilities")

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
@@ -177,17 +177,3 @@ fun Endpoint.Companion.updateGoals(goals: List<String>): Endpoint {
         method = EndpointMethod.POST
     )
 }
-
-fun Endpoint.Companion.getUserTalkingPoints(netID: String = ""): Endpoint =
-    getFieldHelper(netID, "talkingPoints")
-
-fun Endpoint.Companion.updateTalkingPoints(talkingPoints: List<String>): Endpoint {
-    val json = gson.toJson(mapOf("talkingPoints" to talkingPoints))
-    val requestBody = json.toString().toRequestBody("application/json; charset=utf-8".toMediaType())
-    return Endpoint(
-        path = "/user/talkingPoints",
-        headers = authHeader(),
-        body = requestBody,
-        method = EndpointMethod.POST
-    )
-}


### PR DESCRIPTION
## Overview
Update networking for interests, groups, and social media in onboarding. Removed talking points, as they are no longer supported.

## Changes Made
- Add new endpoints and methods for updating interests, groups, and social media
- Update `SocialMedia` and `User` models
- Remove talking points from onboarding flow

## Test Coverage
Play-tested on Pixel 3 @ API 29.

## Next Steps
- Update networking for goals
- Add networking for prompts
- Re-networking for editing profile pages

## Related PRs or Issues
Builds off of #16 