### PR TITLE
Add icons to interests and groups

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,4 +57,9 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
+    // Glide v4 uses this new annotation processor -- see https://bumptech.github.io/glide/doc/generatedapi.html
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.12.0'
+
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
@@ -65,6 +65,7 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
                         UserField(
                             text = it.name,
                             subtext = it.subtitle,
+                            drawableUrl = it.imageUrl,
                             id = it.id
                         )
                     }
@@ -73,7 +74,7 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
                     getAllPurposes().map { UserField(text = it.name, id = it.id) }
                 }
                 Category.GROUP -> {
-                    getAllGroups().map { UserField(text = it.name, id = it.id) }
+                    getAllGroups().map { UserField(text = it.name, drawableUrl = it.imageUrl, id = it.id) }
                 }
             }.toTypedArray()
 

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
@@ -12,6 +12,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
+import com.bumptech.glide.Glide
 import com.cornellappdev.coffee_chats_android.R
 import com.cornellappdev.coffee_chats_android.models.UserField
 
@@ -54,6 +55,10 @@ class UserFieldAdapter(
         } else {
             viewHolder.clubOrInterestSubtext.visibility = View.GONE
         }
+
+        Glide.with(context)
+            .load(currentClubInterest.drawableUrl)
+            .into(viewHolder.icon!!)
 
 //        if (hideIcon) {
 //            viewHolder.icon!!.visibility = View.GONE

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/UserField.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/UserField.kt
@@ -3,7 +3,7 @@ package com.cornellappdev.coffee_chats_android.models
 class UserField(
     private var text: String = "",
     private var subtext: String = "",
-    val drawableId: Int? = null,
+    val drawableUrl: String = "",
     val id: Int = -1
 ) {
     enum class Category {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Added icons to match the different texts in interests and groups.



## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
1. Initialized drawableUrl in UserFieldFragment
2. Used Glide to add the icon images in the UserFieldAdapter
    - now all the interests and groups should have icons to the left of their text



## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Tested by using emulator Pixel 3 API 29. Can see all the icons immediately when you go on the screens for the interests and groups

## Screenshots (delete if not applicable)

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>Icons for Interests</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
<img width="236" alt="Icons for Interests" src="https://user-images.githubusercontent.com/70385317/138196145-78087175-537f-4b89-b910-d6ce898d95d3.png">

</details>

<details>

  <summary>Icons for Groups</summary>

  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
 
<img width="230" alt="Icons for Groups" src="https://user-images.githubusercontent.com/70385317/138196153-a998dde4-ace8-482b-bf1a-0d5e13874738.png">

</details>

