### PR TITLE
Remove spaces for certain icons during onboarding

### DIFF
--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
@@ -2,7 +2,6 @@ package com.cornellappdev.coffee_chats_android
 
 import android.content.res.Resources
 import android.os.Bundle
-import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -10,7 +9,6 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ListView
 import androidx.fragment.app.Fragment
-import com.bumptech.glide.Glide
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter.ItemColor
 import com.cornellappdev.coffee_chats_android.models.UserField
@@ -65,9 +63,7 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
                 val userInterests = user.interests
                 val allInterests = getAllInterests()
                 for (interest in allInterests) {
-                    val item = UserField(interest.name, interest.subtitle, id = interest.id)
-                    //added "interest.imageUrl"
-                    //val item = UserField( interest.name, interest.subtitle, interest.imageUrl, id = interest.id)
+                    val item = UserField( interest.name, interest.subtitle, interest.imageUrl, id = interest.id)
                     if (interest in userInterests) {
                         selectedItems.add(item)
                     } else {
@@ -78,15 +74,12 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
                 val userGroups = user.groups
                 val allGroups = getAllGroups()
                 for (group in allGroups) {
-                    //added "group.imageUrl"
                     val item = UserField(group.name, drawableUrl = group.imageUrl, id = group.id)
                     if (group in userGroups) {
                         selectedItems.add(item)
                     } else {
                         moreItems.add(item)
                     }
-
-
                 }
             }
 

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
@@ -63,7 +63,7 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
                 val userInterests = user.interests
                 val allInterests = getAllInterests()
                 for (interest in allInterests) {
-                    val item = UserField( interest.name, interest.subtitle, interest.imageUrl, id = interest.id)
+                    val item = UserField(interest.name, interest.subtitle, interest.imageUrl, id = interest.id)
                     if (interest in userInterests) {
                         selectedItems.add(item)
                     } else {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/EditInterestsGroupsFragment.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.coffee_chats_android
 
 import android.content.res.Resources
 import android.os.Bundle
+import android.util.Log
 import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
@@ -9,6 +10,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ListView
 import androidx.fragment.app.Fragment
+import com.bumptech.glide.Glide
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter.ItemColor
 import com.cornellappdev.coffee_chats_android.models.UserField
@@ -64,6 +66,8 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
                 val allInterests = getAllInterests()
                 for (interest in allInterests) {
                     val item = UserField(interest.name, interest.subtitle, id = interest.id)
+                    //added "interest.imageUrl"
+                    //val item = UserField( interest.name, interest.subtitle, interest.imageUrl, id = interest.id)
                     if (interest in userInterests) {
                         selectedItems.add(item)
                     } else {
@@ -74,19 +78,23 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
                 val userGroups = user.groups
                 val allGroups = getAllGroups()
                 for (group in allGroups) {
-                    val item = UserField(group.name, id = group.id)
+                    //added "group.imageUrl"
+                    val item = UserField(group.name, drawableUrl = group.imageUrl, id = group.id)
                     if (group in userGroups) {
                         selectedItems.add(item)
                     } else {
                         moreItems.add(item)
                     }
+
+
                 }
             }
+
             selectedItemsAdapter =
-                UserFieldAdapter(requireContext(), selectedItems, ItemColor.GREEN)
+                UserFieldAdapter(requireContext(), selectedItems, ItemColor.GREEN, false)
             selected_items.item_list.adapter = selectedItemsAdapter
             moreItemsAdapter =
-                UserFieldAdapter(requireContext(), moreItems, ItemColor.WHITE)
+                UserFieldAdapter(requireContext(), moreItems, ItemColor.WHITE, false)
             more_items.item_list.adapter = moreItemsAdapter
             view_other_items.setOnClickListener {
                 showExcessSelectedItems = !showExcessSelectedItems

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -47,7 +47,9 @@ class SchedulingActivity :
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_scheduling)
         drawerLayout = findViewById(R.id.drawer_layout)
+
         // determine if the app should show scheduling page, sign-in, or onboarding
+
         val account = GoogleSignIn.getLastSignedInAccount(this)
         if (account != null && preferencesHelper.accessToken != null && preferencesHelper.accessToken!!.isNotEmpty()) {
             // user is already signed in - get user profile

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SignInActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SignInActivity.kt
@@ -108,8 +108,7 @@ class SignInActivity : AppCompatActivity() {
                             setUpNetworking(userSession.accessToken)
                             val user = getUser()
                             val intent = if (user.hasOnboarded) {
-                                //Intent(applicationContext, SchedulingActivity::class.java)
-                                Intent(applicationContext, OnboardingActivity::class.java)
+                                Intent(applicationContext, SchedulingActivity::class.java)
                             } else {
                                 Intent(applicationContext, OnboardingActivity::class.java)
                             }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SignInActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SignInActivity.kt
@@ -108,7 +108,8 @@ class SignInActivity : AppCompatActivity() {
                             setUpNetworking(userSession.accessToken)
                             val user = getUser()
                             val intent = if (user.hasOnboarded) {
-                                Intent(applicationContext, SchedulingActivity::class.java)
+                                //Intent(applicationContext, SchedulingActivity::class.java)
+                                Intent(applicationContext, OnboardingActivity::class.java)
                             } else {
                                 Intent(applicationContext, OnboardingActivity::class.java)
                             }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/UserFieldFragment.kt
@@ -101,7 +101,7 @@ class UserFieldFragment : Fragment(), OnFilledOutObservable {
                     requireContext(),
                     fieldAdapterArray.toList(),
                     UserFieldAdapter.ItemColor.TOGGLE,
-                    true // TODO- display icons
+                    category == Category.GOAL
                 )
             interests_or_groups.adapter = adapter
             // display selected fields

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
@@ -3,7 +3,6 @@ package com.cornellappdev.coffee_chats_android.adapters
 import android.content.Context
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -16,7 +15,6 @@ import androidx.core.content.ContextCompat
 import com.bumptech.glide.Glide
 import com.cornellappdev.coffee_chats_android.R
 import com.cornellappdev.coffee_chats_android.models.UserField
-
 
 class UserFieldAdapter(
     private val mContext: Context,
@@ -62,14 +60,6 @@ class UserFieldAdapter(
             .load(currentClubInterest.drawableUrl)
             .into(viewHolder.icon!!)
 
-
-//        if (hideIcon) {
-//            viewHolder.icon!!.visibility = View.GONE
-//        } else {
-//            viewHolder.icon!!.setImageDrawable(ContextCompat.getDrawable(mContext, currentClubInterest.drawableId!!))
-//        }
-
-        //code for hideIcon
         if (hideIcon) {
             viewHolder.icon!!.visibility = View.GONE
         }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
@@ -3,6 +3,7 @@ package com.cornellappdev.coffee_chats_android.adapters
 import android.content.Context
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -49,6 +50,7 @@ class UserFieldAdapter(
         }
 
         val currentClubInterest = fieldList[position]
+
         viewHolder.clubOrInterestText.text = currentClubInterest.getText()
         if (currentClubInterest.getSubtext().isNotEmpty()) {
             viewHolder.clubOrInterestSubtext.text = currentClubInterest.getSubtext()
@@ -60,11 +62,17 @@ class UserFieldAdapter(
             .load(currentClubInterest.drawableUrl)
             .into(viewHolder.icon!!)
 
+
 //        if (hideIcon) {
 //            viewHolder.icon!!.visibility = View.GONE
 //        } else {
 //            viewHolder.icon!!.setImageDrawable(ContextCompat.getDrawable(mContext, currentClubInterest.drawableId!!))
 //        }
+
+        //code for hideIcon
+        if (hideIcon) {
+            viewHolder.icon!!.visibility = View.GONE
+        }
 
         val selected = ContextCompat.getColor(context, R.color.onboardingListSelected)
         val unselected = ContextCompat.getColor(context, R.color.onboarding_fields)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/Interest.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/Interest.kt
@@ -9,5 +9,5 @@ data class Interest(
     val name: String,
     val subtitle: String,
     @Json(name = "img_url")
-    val imageUrl: String
+    val imageUrl: String = ""
 )

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/Match.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/Match.kt
@@ -1,0 +1,10 @@
+package com.cornellappdev.coffee_chats_android.models
+
+import com.squareup.moshi.Json
+
+data class Match(
+    val id: Int,
+    val status: String,
+    @Json(name = "matched_user")
+    val matchedUser: User
+)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
@@ -36,6 +36,5 @@ data class User(
     val hasOnboarded: Boolean,
     @Json(name = "pending_feedback")
     val pendingFeedback: Boolean
-//    @Json(name = "current_match")
-//    val currentMatch: Match?
+    // TODO add current match field
 )

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
@@ -35,7 +35,7 @@ data class User(
     @Json(name = "has_onboarded")
     val hasOnboarded: Boolean,
     @Json(name = "pending_feedback")
-    val pendingFeedback: Boolean,
-    @Json(name = "current_match")
-    val currentMatch: User?
+    val pendingFeedback: Boolean
+//    @Json(name = "current_match")
+//    val currentMatch: Match?
 )


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Remove spaces in the "How do you want to use Pear?" section of onboarding since they don't have icons, ensure that the icons still appear though for the groups and interests section of onboarding



## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
Set hideIcon to true as the default in the UserFieldAdapter. Then in the EditInterestsGroupsFragment, set the hideIcon parameter to false when the adapter is being instantiated so that the icons appear for the groups and interests. 



## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Test this feature by logging out of current account and going through the onboarding process again to see the icons appear for the group section and not appear for the "How do you want to use Pear section?".


## Screenshots (delete if not applicable)

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>remove_space_icon</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
 
https://user-images.githubusercontent.com/70385317/142515104-da7e9eec-ffa6-494b-b94d-ec3182caa418.mp4

 <summary>screenshots of group and interests</summary>
<img width="195" alt="Screen Shot 2021-11-19 at 3 23 31 PM" src="https://user-images.githubusercontent.com/70385317/142687155-3488adc6-abbe-4274-ac7c-b6b4d48f6b2d.png">

<img width="196" alt="Screen Shot 2021-11-19 at 3 23 11 PM" src="https://user-images.githubusercontent.com/70385317/142687165-edca6434-8db2-447f-aebb-c3f70b3ac4e9.png">


</details>
