### PR TITLE
Fix messaging and sign-in bugs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
         <activity
             android:name=".MessagingActivity"
             android:exported="false"
-            android:theme="@style/noAnimTheme" />
+            android:theme="@style/noAnimTheme"
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".ProfileSettingsActivity"
             android:theme="@style/noAnimTheme" />

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -40,8 +40,6 @@ class SchedulingActivity :
     }
     private val noMatchTag = "NO_MATCH"
     private val matchTag = "MATCH"
-    private val scheduleTimeTag = "SCHEDULING_TIME"
-    private val schedulePlaceTag = "SCHEDULING_PLACE"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,7 +52,12 @@ class SchedulingActivity :
             // user is already signed in - get user profile
             CoroutineScope(Dispatchers.Main).launch {
                 setUpNetworking(preferencesHelper.accessToken!!)
-                user = getUser()
+                try {
+                    user = getUser()
+                } catch (e : Exception) {
+                    // login error, prompt user to sign in
+                    signIn()
+                }
                 // move to onboarding if user hasn't finished
                 if (!user.hasOnboarded) {
                     val intent = Intent(applicationContext, OnboardingActivity::class.java)
@@ -234,31 +237,6 @@ class SchedulingActivity :
             }
             startActivity(messagingIntent)
         }
-    }
-
-    private fun onNextPage() {
-        if (page == 2) {
-            val locationFragment =
-                supportFragmentManager.findFragmentByTag(schedulePlaceTag) as SchedulingPlaceFragment
-            locationFragment.saveInformation()
-            page = 0
-            setUpCurrentPage()
-            supportFragmentManager.popBackStack(noMatchTag, 0)
-            return
-        }
-        if (page < 2) page++
-        val ft: FragmentTransaction = supportFragmentManager.beginTransaction()
-        if (page == 1) {
-            ft.replace(fragmentContainer.id, SchedulingTimeFragment(), scheduleTimeTag)
-        } else {
-            val timeFragment =
-                supportFragmentManager.findFragmentByTag(scheduleTimeTag) as SchedulingTimeFragment
-            timeFragment.saveInformation()
-            ft.replace(fragmentContainer.id, SchedulingPlaceFragment(), schedulePlaceTag)
-        }
-        setUpCurrentPage()
-        ft.addToBackStack("ft")
-        ft.commit()
     }
 
     private fun setUpCurrentPage() {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/ChatAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/ChatAdapter.kt
@@ -42,11 +42,18 @@ class ChatAdapter(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val message = messages[position]
-        // display message and profile image as needed
+        // display message
         val isUserMessage = message.senderId == userId
         val textView = if (isUserMessage) holder.userChatTextView else holder.pearChatTextView
+        // hide other textview
+        if (isUserMessage) {
+            holder.pearChatTextView.visibility = View.GONE
+        } else {
+            holder.userChatTextView.visibility = View.GONE
+        }
         textView.text = message.message
         textView.visibility = View.VISIBLE
+        // display profile picture as needed
         if (!isUserMessage) {
             val c = holder.itemView.context
             holder.pearProfileImageView.visibility = View.VISIBLE
@@ -61,12 +68,16 @@ class ChatAdapter(
                     c.startActivity(this)
                 }
             }
+        } else {
+            holder.pearProfileImageView.visibility = View.GONE
         }
         // display date as needed
         val currDate = getFormattedDate(messages[position])
         if (position == 0 || getFormattedDate(messages[position - 1]) != currDate) {
             holder.dateStamp.visibility = View.VISIBLE
             holder.dateStamp.text = currDate
+        } else {
+            holder.dateStamp.visibility = View.GONE
         }
         holder.itemView.setOnClickListener {
             hideKeyboard(holder.itemView.context, holder.itemView)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/ChatFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/ChatFragment.kt
@@ -55,7 +55,14 @@ class ChatFragment : Fragment(), MessageObserver {
                 if (it == -1) messages.size else it
             }
         messages.add(insertionIndex, message)
+        // update this message and surrounding messages to avoid datestamp issues
         adapter.notifyItemInserted(insertionIndex)
+        if (insertionIndex - 1 >= 0) {
+            adapter.notifyItemChanged(insertionIndex - 1)
+        }
+        if (insertionIndex + 1 < messages.size) {
+            adapter.notifyItemChanged(insertionIndex + 1)
+        }
         recyclerView.scrollToPosition(adapter.itemCount - 1)
         if (emptyChatView.visibility == View.VISIBLE) {
             emptyChatView.visibility = View.GONE


### PR DESCRIPTION
## Overview
Fix UI bugs with messaging and fix a bug that caused crashing on app start.

## Changes Made
Messaging UI Fixes

- Fixed a bug where 2 chat bubbles would appear on the same line
- Fixed bug with more datestamps showing up than was necessary
- Fixed bug where the profile picture for the pear would show up even when it was not supposed to
- Made the messages view move up when the keyboard is visible

Login Bug Fix

- Prompt user to sign in if the initial network request to fetch their profile is unsuccessful. This fixes the bug where, if using an invalidated access token, the app would crash on app start

Miscellaneous

- Removed unneeded code in `SchedulingActivity`

## Test Coverage
Play-tested on Samsung S9.