### PR TITLE
[People Page][2/X] Integrate people page with tab navigation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,13 +22,11 @@ android {
     buildTypes {
         debug {
             buildConfigField("String", "BACKEND_URI", "\"pear-backend.cornellappdev.com\"")
-            manifestPlaceholders = [usesCleartextTraffic: "true"]
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         release {
             buildConfigField("String", "BACKEND_URI", "\"pear-backend.cornellappdev.com\"")
-            manifestPlaceholders = [usesCleartextTraffic: "false"]
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
-        android:usesCleartextTraffic="${usesCleartextTraffic}">
+        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
         <activity
             android:name=".ProfileActivity"
             android:exported="false" />

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -323,7 +323,7 @@ class SchedulingActivity :
         feedbackButton.visibility = View.VISIBLE
     }
 
-    fun showPopup(v: View) {
+    private fun showPopup(v: View) {
         // style wrapper
         val wrapper = ContextThemeWrapper(this, R.style.popUpTheme_PopupMenu)
         val popup = PopupMenu(wrapper, v)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -58,30 +58,30 @@ class SchedulingActivity :
                 setUpNetworking(preferencesHelper.accessToken!!)
                 try {
                     user = getUser()
+                    // move to onboarding if user hasn't finished
+                    if (!user.hasOnboarded) {
+                        val intent = Intent(applicationContext, OnboardingActivity::class.java)
+                        intent.putExtra(ACCESS_TOKEN_TAG, preferencesHelper.accessToken!!)
+                        startActivity(intent)
+                    } else {
+                        setUpDrawerLayout()
+                        if (user.currentMatch == null) {
+                            primaryActionButton.visibility = View.GONE
+                            ft.add(fragmentContainer.id, NoMatchFragment()).addToBackStack(noMatchTag)
+                            ft.commit()
+                            headerText.text = getString(R.string.no_match_header)
+                        } else {
+                            ft.add(
+                                fragmentContainer.id,
+                                ProfileFragment.newInstance(user.currentMatch!!.matchedUser)
+                            ).addToBackStack(matchTag)
+                            ft.commit()
+                            headerText.text = getString(R.string.match_header)
+                        }
+                    }
                 } catch (e : Exception) {
                     // login error, prompt user to sign in
                     signIn()
-                }
-                // move to onboarding if user hasn't finished
-                if (!user.hasOnboarded) {
-                    val intent = Intent(applicationContext, OnboardingActivity::class.java)
-                    intent.putExtra(ACCESS_TOKEN_TAG, preferencesHelper.accessToken!!)
-                    startActivity(intent)
-                } else {
-                    setUpDrawerLayout()
-                    if (user.currentMatch == null) {
-                        primaryActionButton.visibility = View.GONE
-                        ft.add(fragmentContainer.id, NoMatchFragment()).addToBackStack(noMatchTag)
-                        ft.commit()
-                        headerText.text = getString(R.string.no_match_header)
-                    } else {
-                        ft.add(
-                            fragmentContainer.id,
-                            ProfileFragment.newInstance(user.currentMatch!!.matchedUser)
-                        ).addToBackStack(matchTag)
-                        ft.commit()
-                        headerText.text = getString(R.string.match_header)
-                    }
                 }
             }
         } else {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -106,9 +106,15 @@ class SchedulingActivity :
             // prompt user to log in
             signIn()
         }
-
+        // hide fragment container and header- replaced by TabLayout + ViewPager
+        fragmentContainer.visibility = View.GONE
+        headerText.visibility = View.GONE
+        tabLayout.visibility = View.VISIBLE
         primaryActionButton.setOnClickListener {
             onSendMessageClick()
+        }
+        feedbackButton.setOnClickListener {
+            showPopup(it)
         }
 
         // set up navigation view

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -69,8 +69,12 @@ class SchedulingActivity :
                     } else {
                         setUpDrawerLayout()
                         val c = this@SchedulingActivity
+                        val isUserMatched = user.currentMatch != null
+                        if (!isUserMatched) {
+                            primaryActionButton.visibility = View.GONE
+                        }
                         viewPager.adapter =
-                            ViewPagerAdapter(c, user.currentMatch != null)
+                            ViewPagerAdapter(c, isUserMatched)
                         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
                             tab.text =
                                 if (position == 0) c.getText(R.string.match_header)
@@ -89,7 +93,7 @@ class SchedulingActivity :
                             addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
                                 override fun onTabSelected(tab: TabLayout.Tab?) {
                                     primaryActionButton.visibility =
-                                        if (tab?.text.toString() == c.getText(R.string.match_header)) {
+                                        if (tab?.text.toString() == c.getText(R.string.match_header) && isUserMatched) {
                                             View.VISIBLE
                                         } else {
                                             View.GONE

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -19,12 +19,15 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.bumptech.glide.Glide
-import com.cornellappdev.coffee_chats_android.fragments.*
+import com.cornellappdev.coffee_chats_android.fragments.NoMatchFragment
+import com.cornellappdev.coffee_chats_android.fragments.PeopleFragment
+import com.cornellappdev.coffee_chats_android.fragments.ProfileFragment
 import com.cornellappdev.coffee_chats_android.models.User
 import com.cornellappdev.coffee_chats_android.networking.getUser
 import com.cornellappdev.coffee_chats_android.networking.setUpNetworking
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.material.navigation.NavigationView
+import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.android.synthetic.main.activity_scheduling.*
 import kotlinx.android.synthetic.main.nav_header_profile.view.*
@@ -76,28 +79,30 @@ class SchedulingActivity :
                         // resize tabs so they wrap tab text
                         tabLayout.apply {
                             for (i in 0 until NUM_FRAGMENTS) {
-                                val layout = (this.getChildAt(0) as LinearLayout).getChildAt(0) as LinearLayout
+                                val layout =
+                                    (this.getChildAt(0) as LinearLayout).getChildAt(0) as LinearLayout
                                 val layoutParams = layout.layoutParams as LinearLayout.LayoutParams
                                 layoutParams.weight = 0f
                                 layoutParams.width = LinearLayout.LayoutParams.WRAP_CONTENT
                                 layout.layoutParams = layoutParams
                             }
-                        }
-                        if (user.currentMatch == null) {
-                            primaryActionButton.visibility = View.GONE
-                            ft.add(fragmentContainer.id, NoMatchFragment()).addToBackStack(noMatchTag)
-                            ft.commit()
-                            headerText.text = getString(R.string.no_match_header)
-                        } else {
-                            ft.add(
-                                fragmentContainer.id,
-                                ProfileFragment.newInstance(user.currentMatch!!.matchedUser)
-                            ).addToBackStack(matchTag)
-                            ft.commit()
-                            headerText.text = getString(R.string.match_header)
+                            addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+                                override fun onTabSelected(tab: TabLayout.Tab?) {
+                                    primaryActionButton.visibility =
+                                        if (tab?.text.toString() == c.getText(R.string.match_header)) {
+                                            View.VISIBLE
+                                        } else {
+                                            View.GONE
+                                        }
+                                }
+
+                                override fun onTabUnselected(tab: TabLayout.Tab?) {}
+
+                                override fun onTabReselected(tab: TabLayout.Tab?) {}
+                            })
                         }
                     }
-                } catch (e : Exception) {
+                } catch (e: Exception) {
                     // login error, prompt user to sign in
                     signIn()
                 }
@@ -287,7 +292,8 @@ class SchedulingActivity :
             primaryActionButton.setPadding(100, 0, 100, 0)
         } else {
             backButton.background = ContextCompat.getDrawable(this, R.drawable.ic_back_carrot)
-            feedbackButton.background = ContextCompat.getDrawable(this, R.drawable.ic_feedback_button)
+            feedbackButton.background =
+                ContextCompat.getDrawable(this, R.drawable.ic_feedback_button)
             backButton.layoutParams = backButton.layoutParams.apply {
                 height = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 18f, displayMetrics)
                     .toInt()
@@ -322,7 +328,7 @@ class SchedulingActivity :
         popup.show()
 
         popup.setOnMenuItemClickListener {
-            when(it.itemId){
+            when (it.itemId) {
                 R.id.nav_send_feedback -> {
                     val i = Intent(Intent.ACTION_VIEW)
                     i.data = Uri.parse(getString(R.string.feedback_url))
@@ -330,11 +336,17 @@ class SchedulingActivity :
                     true
                 }
                 R.id.nav_contact_us -> {
-                    sendEmail(getString(R.string.feedback_email), getString(R.string.feedback_contact))
+                    sendEmail(
+                        getString(R.string.feedback_email),
+                        getString(R.string.feedback_contact)
+                    )
                     true
                 }
                 R.id.nav_report_user -> {
-                    sendEmail(getString(R.string.feedback_email), getString(R.string.feedback_report))
+                    sendEmail(
+                        getString(R.string.feedback_email),
+                        getString(R.string.feedback_report)
+                    )
                     true
                 }
             }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/PeopleAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/PeopleAdapter.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.cornellappdev.coffee_chats_android.ProfileActivity
 import com.cornellappdev.coffee_chats_android.R
+import com.cornellappdev.coffee_chats_android.hideKeyboard
 import com.cornellappdev.coffee_chats_android.models.PearUser
 import kotlinx.android.synthetic.main.people_cell.view.*
 import kotlinx.android.synthetic.main.people_pill_view.view.*
@@ -77,6 +78,7 @@ class PeopleAdapter(private val people: List<PearUser>) :
             itemView.setOnClickListener {
                 val intent = Intent(c, ProfileActivity::class.java)
                 intent.putExtra(ProfileActivity.USER_ID, user.id)
+                hideKeyboard(c, it)
                 c.startActivity(intent)
             }
         }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/PeopleAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/PeopleAdapter.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.coffee_chats_android.adapters
 
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +10,7 @@ import androidx.constraintlayout.helper.widget.Flow
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.cornellappdev.coffee_chats_android.ProfileActivity
 import com.cornellappdev.coffee_chats_android.R
 import com.cornellappdev.coffee_chats_android.models.PearUser
 import kotlinx.android.synthetic.main.people_cell.view.*
@@ -71,6 +73,12 @@ class PeopleAdapter(private val people: List<PearUser>) :
                 }
             }
             interestsFlow.referencedIds = ids.toIntArray()
+            // navigate to user profile on click
+            itemView.setOnClickListener {
+                val intent = Intent(c, ProfileActivity::class.java)
+                intent.putExtra(ProfileActivity.USER_ID, user.id)
+                c.startActivity(intent)
+            }
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/PeopleFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/PeopleFragment.kt
@@ -50,6 +50,7 @@ class PeopleFragment : Fragment() {
         CoroutineScope(Dispatchers.Main).launch {
             val users = getAllUsers(query ?: "")
             recyclerView.adapter = PeopleAdapter(users)
+            loadingIcon.visibility = View.GONE
         }
     }
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/PeopleFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/PeopleFragment.kt
@@ -32,13 +32,16 @@ class PeopleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         search.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
-                updateUsers(query)
-                hideKeyboard(requireContext(), search)
                 search.clearFocus()
-                return true
+                search.setQuery(query, false)
+                hideKeyboard(requireContext(), search)
+                return false
             }
 
-            override fun onQueryTextChange(query: String?): Boolean = false
+            override fun onQueryTextChange(query: String?): Boolean {
+                updateUsers(query)
+                return true
+            }
 
         })
         recyclerView.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/ChatFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/ChatFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.cornellappdev.coffee_chats_android.R
@@ -70,7 +71,7 @@ class ChatFragment : Fragment(), MessageObserver {
     }
 
     override fun onMessageSendFailed() {
-        // TODO - display Toast to inform users
+        Toast.makeText(requireContext(), R.string.message_send_error, Toast.LENGTH_SHORT).show()
     }
 
     private fun sendMessage() {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/Endpoint.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/Endpoint.kt
@@ -16,12 +16,12 @@ class Endpoint(
     private val method: EndpointMethod,
     private val useDefaultHost: Boolean = true
 ) {
-    private val host = "http://${BuildConfig.BACKEND_URI}/api"
+    private val host = "https://${BuildConfig.BACKEND_URI}/api"
 
     companion object
 
     fun okHttpRequest(): Request {
-        val endpoint = if (useDefaultHost) host + path else path
+        val endpoint = if (useDefaultHost) host + path else "https://$path"
         val headers = headers.toHeaders()
 
         return when (method) {

--- a/app/src/main/res/drawable/ic_paper_plane_right.xml
+++ b/app/src/main/res/drawable/ic_paper_plane_right.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20.5815,11.3456L4.7457,2.4776C4.6125,2.403 4.4597,2.3708 4.3077,2.3854C4.1557,2.4 4.0118,2.4606 3.8951,2.5591C3.7785,2.6577 3.6948,2.7895 3.6551,2.9369C3.6154,3.0844 3.6216,3.2404 3.673,3.3842L6.6599,11.7477C6.7182,11.9109 6.7182,12.0891 6.6599,12.2522L3.673,20.6158C3.6216,20.7596 3.6154,20.9156 3.6551,21.063C3.6948,21.2105 3.7785,21.3423 3.8951,21.4408C4.0118,21.5394 4.1557,21.6 4.3077,21.6146C4.4597,21.6292 4.6125,21.597 4.7457,21.5224L20.5815,12.6544C20.6978,12.5892 20.7947,12.4943 20.8621,12.3792C20.9295,12.2642 20.965,12.1333 20.965,12C20.965,11.8667 20.9295,11.7358 20.8621,11.6207C20.7947,11.5057 20.6978,11.4108 20.5815,11.3456V11.3456Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6.75,12H12.75"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/activity_scheduling.xml
+++ b/app/src/main/res/layout/activity_scheduling.xml
@@ -30,9 +30,26 @@
                 android:background="@drawable/ic_back_carrot"
                 android:clickable="true"
                 android:focusable="true"
-                app:layout_constraintBottom_toBottomOf="@id/headerText"
+                app:layout_constraintBottom_toBottomOf="@id/tabLayout"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toTopOf="@id/headerText" />
+                app:layout_constraintTop_toTopOf="@id/tabLayout" />
+
+            <com.google.android.material.tabs.TabLayout
+                android:id="@+id/tabLayout"
+                android:layout_width="0dp"
+                android:layout_height="40dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginHorizontal="74dp"
+                android:layout_marginTop="44dp"
+                android:background="@drawable/rounded_shape_white"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tabIndicatorColor="@color/transparent"
+                app:tabMode="fixed"
+                app:tabSelectedTextColor="@color/forest_green"
+                app:tabTextAppearance="@style/tabLayoutTheme"
+                app:tabTextColor="@color/secondary_green_grey" />
 
             <TextView
                 android:id="@+id/headerText"
@@ -46,6 +63,7 @@
                 android:text="@string/no_match_header"
                 android:textColor="@color/black"
                 android:textSize="24sp"
+                android:visibility="gone"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -82,12 +100,22 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/viewPager"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginVertical="5dp"
+            app:layout_constraintBottom_toTopOf="@id/primaryActionButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/headerLayout" />
 
         <FrameLayout
             android:id="@+id/fragmentContainer"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginVertical="5dp"
+            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/primaryActionButton"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -98,7 +126,7 @@
             style="?android:attr/borderlessButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="50dp"
-            android:layout_marginBottom="60dp"
+            android:layout_marginBottom="50dp"
             android:background="@drawable/profile_button_background"
             android:elevation="3dp"
             android:enabled="true"

--- a/app/src/main/res/layout/activity_scheduling.xml
+++ b/app/src/main/res/layout/activity_scheduling.xml
@@ -126,6 +126,7 @@
             android:layout_height="50dp"
             android:layout_marginBottom="50dp"
             android:background="@drawable/profile_button_background"
+            android:drawableStart="@drawable/ic_paper_plane_right"
             android:elevation="3dp"
             android:enabled="true"
             android:fontFamily="@font/circular_medium"

--- a/app/src/main/res/layout/activity_scheduling.xml
+++ b/app/src/main/res/layout/activity_scheduling.xml
@@ -104,7 +104,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginVertical="5dp"
-            app:layout_constraintBottom_toTopOf="@id/primaryActionButton"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/headerLayout" />

--- a/app/src/main/res/layout/activity_scheduling.xml
+++ b/app/src/main/res/layout/activity_scheduling.xml
@@ -19,6 +19,7 @@
             android:id="@+id/headerLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="44dp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
@@ -30,9 +31,9 @@
                 android:background="@drawable/ic_back_carrot"
                 android:clickable="true"
                 android:focusable="true"
-                app:layout_constraintBottom_toBottomOf="@id/tabLayout"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toTopOf="@id/tabLayout" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tabLayout"
@@ -40,8 +41,8 @@
                 android:layout_height="40dp"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginHorizontal="74dp"
-                android:layout_marginTop="44dp"
                 android:background="@drawable/rounded_shape_white"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
@@ -56,16 +57,15 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="70dp"
-                android:layout_marginTop="60dp"
                 android:layout_marginRight="70dp"
                 android:fontFamily="@font/circular_medium"
                 android:gravity="center"
                 android:text="@string/no_match_header"
                 android:textColor="@color/black"
                 android:textSize="24sp"
-                android:visibility="gone"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <Button
@@ -79,24 +79,23 @@
                 android:textColor="@color/save_button_text_color"
                 android:textSize="20sp"
                 android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@id/headerText"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="@id/headerText" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <ImageButton
                 android:id="@+id/feedbackButton"
                 android:layout_width="26.67dp"
                 android:layout_height="26.67dp"
-                android:background="@drawable/ic_feedback_button"
                 android:layout_marginEnd="24dp"
-                android:paddingBottom="40dp"
+                android:background="@drawable/ic_feedback_button"
                 android:clickable="true"
                 android:focusable="true"
-                app:layout_constraintBottom_toBottomOf="@id/headerText"
+                android:paddingBottom="40dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/tabLayout"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="@id/headerText"
-                android:onClick="showPopup"
-                android:visibility="gone"/>
+                app:layout_constraintTop_toTopOf="@id/tabLayout" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -115,7 +114,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginVertical="5dp"
-            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/primaryActionButton"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -46,6 +46,7 @@
             android:hint="@string/send_message_hint"
             android:maxHeight="@dimen/chat_edit_text_max_height"
             android:padding="@dimen/chat_bubble_padding"
+            android:textColor="@color/black"
             android:textColorHint="@color/secondary_green_grey"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/sendMessageButton"

--- a/app/src/main/res/layout/fragment_no_match.xml
+++ b/app/src/main/res/layout/fragment_no_match.xml
@@ -1,9 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@color/background_green">
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="70dp"
+        android:layout_marginTop="@dimen/no_match_margin_vertical"
+        android:layout_marginRight="70dp"
+        android:fontFamily="@font/circular_medium"
+        android:gravity="center"
+        android:text="@string/no_match_header"
+        android:textColor="@color/black"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/no_match_image"
@@ -21,16 +36,16 @@
         android:id="@+id/no_match_subheader"
         android:layout_width="293dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
+        android:layout_marginBottom="@dimen/no_match_margin_vertical"
         android:fontFamily="@font/circular_book"
         android:gravity="center"
         android:text="@string/no_match_subheader"
         android:textColor="@color/text_dark_green"
-        android:textSize="16dp"
+        android:textSize="16sp"
+        android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/no_match_image" />
+        app:layout_constraintRight_toRightOf="parent" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_people.xml
+++ b/app/src/main/res/layout/fragment_people.xml
@@ -22,6 +22,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ProgressBar
+        android:id="@+id/loadingIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminateDuration="200"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/search" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/background_green"
-        android:paddingBottom="110dp">
+        android:paddingBottom="@dimen/profile_padding_bottom">
 
         <androidx.cardview.widget.CardView
             android:id="@+id/user_image_card_view"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -10,7 +10,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/background_green">
+        android:background="@color/background_green"
+        android:paddingBottom="110dp">
 
         <androidx.cardview.widget.CardView
             android:id="@+id/user_image_card_view"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,6 +5,9 @@
     <dimen name="people_cell_padding">10dp</dimen>
     <dimen name="search_bar_height">40dp</dimen>
 
+    <!-- NoMatchFragment-->
+    <dimen name="no_match_margin_vertical">20dp</dimen>
+
     <!-- MESSAGING -->
     <dimen name="profile_pic_margin">15dp</dimen>
     <dimen name="text_profile_pic_margin">6dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,7 +5,10 @@
     <dimen name="people_cell_padding">10dp</dimen>
     <dimen name="search_bar_height">40dp</dimen>
 
-    <!-- NoMatchFragment-->
+    <!-- ProfileFragment -->
+    <dimen name="profile_padding_bottom">110dp</dimen>
+
+    <!-- NoMatchFragment -->
     <dimen name="no_match_margin_vertical">20dp</dimen>
 
     <!-- MESSAGING -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="current_pear">Current Pear</string>
     <string name="default_week_stamp">1 Week ago</string>
     <string name="week_stamp">%1$d Weeks ago</string>
+    <string name="message_send_error">Message failed to send</string>
 
     <!--PROFILE-->
     <string name="reach_me">Reach me at %1$s</string>
@@ -211,10 +212,10 @@
     <string name="profile_groups_header">Groups I\'m a part of</string>
 
     <!--NO MATCH PAGE-->
-    <string name="no_match_header">Meet your new Pear next Monday</string>
+    <string name="no_match_header">Meet your new Pear next Sunday</string>
     <string name="no_match_subheader">
-        In the meantime, tell me when you\'re
-        usually free to make meeting up easier!
+        In the meantime, browse the people
+        page to see who else is on the app!
     </string>
     <string name="no_match_availability">Enter Availability</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="dummy_name">First Last</string>
 
     <!--PEOPLE-->
+    <string name="people_header">People</string>
     <string name="user_info">%1$s · %2$s · %3$s</string>
 
     <!--SCHEDULING TIME-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,7 @@
     <string name="facebook_profile">Facebook profile link</string>
 
     <!--MESSAGING-->
-    <string name="send_message">Send a Message</string>
+    <string name="send_message">\tSend a Message</string>
     <string name="send_message_hint">Say hi</string>
     <string name="messages_header">Messages</string>
     <string name="messages_subheader">Keep in touch with each other : )</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -27,4 +27,12 @@
         <item name="android:fontFamily">@font/circular_book</item>
         <item name="android:textAlignment">center</item>
     </style>
+
+    <style name="tabLayoutTheme" parent="Widget.Design.TabLayout">
+        <item name="android:textAlignment">center</item>
+        <item name="android:textSize">16sp</item>
+        <item name="font">@font/circular_book</item>
+        <item name="fontWeight">900</item>
+        <item name="textAllCaps">false</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,9 +23,10 @@
     </style>
 
     <style name="popUpTheme.PopupMenu" parent="Widget.AppCompat.PopupMenu">
-        <item name="android:textColor">@color/black</item>
+        <item name="android:itemBackground">@color/white</item>
         <item name="android:fontFamily">@font/circular_book</item>
         <item name="android:textAlignment">center</item>
+        <item name="android:textColor">@color/black</item>
     </style>
 
     <style name="tabLayoutTheme" parent="Widget.Design.TabLayout">


### PR DESCRIPTION
## Overview
Set up `ViewPager` and `TabLayout` for two-tab navigation in `SchedulingActivity`, made primary action button float, switched to HTTPS for networking, and fixed some bugs.

## Changes Made
`SchedulingActivity` + People Page
- Set up `ViewPager` and `TabLayout` to display the user's current match and the people page in separate tabs
- Navigate to user profile on clicking a profile in the people page
- Add a loading icon for the people page
- Add live search for people page so search results are updated as user types
- Make "Send a Message" button float above the current match's profile
- Add icon to left of "Send a Message" button
- Update `NoMatchFragment` for parity with iOS

Networking
- Changed networking URLs to HTTPS, and removed `usesClearTextTraffic` since that's only required for HTTP networking calls

Bug fixes
- Moved some code into a `try` block inside `onCreate` in `SchedulingActivity` to prevent a lateinit var from being used before initialization
- Add a toast to be displayed when a message fails to send
- Make chat `EditText` text color black to prevent dark mode bugs
- Explicitly set background color of popup menu to prevent dark mode bugs

## Test Coverage
Play-tested on Samsung S9 @ API 29. Tested image upload as well, since the URL for that was also changed.

## Next Steps
- Change primary action button to be inside a fragment instead of inside `SchedulingActivity`- this will allow the button to move with the tab when swiping to change tabs. 

## Related PRs or Issues
Builds off of #29 .

## Screenshots
See also a screen recording in #pear-android for the people page.

<details>

  <summary>NoMatchFragment</summary>

  <p>
    <img width="250" height="500" src="https://user-images.githubusercontent.com/19438967/157597194-06904589-4760-49ee-b4cd-81a59919a9ba.jpg">
    <img width="250" height="500" src="https://user-images.githubusercontent.com/19438967/157597223-66046d6a-82fe-408d-a871-5d739eebb273.jpg">
  </p>
  

</details>
