### PR TITLE
Remove availability and location editing from settings

### DIFF
--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
@@ -107,20 +107,6 @@ class ProfileSettingsActivity : AppCompatActivity(), OnFilledOutListener {
     val settingsNavigationListener = fun(menuItem: MenuItem): Boolean {
         val ft: FragmentTransaction = supportFragmentManager.beginTransaction()
         when (menuItem.itemId) {
-            R.id.nav_availabilities -> {
-                content = Content.EDIT_TIME
-                setUpCurrentPage()
-                ft.replace(fragmentContainer.id, SchedulingTimeFragment(), content.name)
-                    .addToBackStack("ft")
-                    .commit()
-            }
-            R.id.nav_location -> {
-                content = Content.EDIT_LOCATION
-                setUpCurrentPage()
-                ft.replace(fragmentContainer.id, SchedulingPlaceFragment(), content.name)
-                    .addToBackStack("ft")
-                    .commit()
-            }
             R.id.nav_social_media -> {
                 content = Content.SOCIAL_MEDIA
                 setUpCurrentPage()

--- a/app/src/main/res/menu/settings.xml
+++ b/app/src/main/res/menu/settings.xml
@@ -5,14 +5,6 @@
 
     <group android:checkableBehavior="single">
         <item
-            android:id="@+id/nav_availabilities"
-            android:icon="@drawable/ic_availability_icon"
-            android:title="@string/edit_availabilities" />
-        <item
-            android:id="@+id/nav_location"
-            android:icon="@drawable/ic_location_icon"
-            android:title="@string/edit_location" />
-        <item
             android:id="@+id/nav_social_media"
             android:icon="@drawable/ic_envelope"
             android:title="@string/connect_social_media" />


### PR DESCRIPTION
## Overview
Removed options to edit availabilities and locations from settings, since those have been replaced with messaging, and clicking on those options in the settings causes a crash.

## Changes Made
- Removed availability and locations editing from the settings menu XML
- Removed availability and locations editing from the navigation listener

## Test Coverage
Play-tested on Samsung S9 @ API 29.

## Screenshots

<details>

  <summary>Updated Settings</summary>

  <p>
    <img src="https://user-images.githubusercontent.com/19438967/158070428-97f7accb-6f79-4787-8f34-c2c35aa8ba78.jpg" width="400" height="800" />
  </p>


</details>
