### PR TITLE
Make minor pre-launch fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ captures
 keys.properties
 google-services.json
 app/src/main/res/values/secrets.xml
+// keys 
+*.pepk
+// keystores
+*.jks
+// app bundles
+*.aab

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 30
     defaultConfig {
-        applicationId "com.example.coffee_chats_android"
+        applicationId "com.cornellappdev.coffee_chats_android"
         minSdkVersion 23
         targetSdkVersion 30
         versionCode 1


### PR DESCRIPTION
## Overview
Change package name in `app/build.gradle` so Pear can be submitted to the Play Store, and added a few launch-related artifacts to the `.gitignore`.

## Test Coverage
Play-tested on Samsung S9 @ API 29.
