### PR TITLE
Fix messaging bugs

### DIFF
--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/ChatFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/ChatFragment.kt
@@ -75,8 +75,11 @@ class ChatFragment : Fragment(), MessageObserver {
     }
 
     private fun sendMessage() {
-        sendMessage(sendMessageEditText.text.toString(), userId!!, pearId!!, this)
-        sendMessageEditText.text.clear()
+        val message = sendMessageEditText.text.toString()
+        if (message.isNotBlank()) {
+            sendMessage(message, userId!!, pearId!!, this)
+            sendMessageEditText.text.clear()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/MessagesFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/MessagesFragment.kt
@@ -40,15 +40,16 @@ class MessagesFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         CoroutineScope(Dispatchers.Main).launch {
-            val currentPearId = getCurrentMatch()?.matchedUser?.id
-            if (currentPearId != null) {
-                adapter = MessageAdapter(getSelfMatches(userId!!), currentPearId) {
+            val pears = getSelfMatches(userId!!)
+            if (pears.isEmpty()) {
+                emptyMessagesView.visibility = View.VISIBLE
+            } else {
+                val currentPearId = getCurrentMatch()?.matchedUser?.id
+                adapter = MessageAdapter(pears, currentPearId) {
                     container.addChatFragment(userId!!, it.id, it.firstName, it.profilePicUrl!!)
                 }
                 recyclerView.adapter = adapter
                 recyclerView.layoutManager = LinearLayoutManager(requireContext())
-            } else {
-                emptyMessagesView.visibility = View.VISIBLE
             }
         }
     }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/MessagesFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/messaging/MessagesFragment.kt
@@ -10,7 +10,8 @@ import com.cornellappdev.coffee_chats_android.R
 import com.cornellappdev.coffee_chats_android.adapters.MessageAdapter
 import com.cornellappdev.coffee_chats_android.networking.getCurrentMatch
 import com.cornellappdev.coffee_chats_android.networking.getSelfMatches
-import kotlinx.android.synthetic.main.fragment_chat.*
+import kotlinx.android.synthetic.main.fragment_chat.recyclerView
+import kotlinx.android.synthetic.main.fragment_messages.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -40,11 +41,15 @@ class MessagesFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         CoroutineScope(Dispatchers.Main).launch {
             val currentPearId = getCurrentMatch()?.matchedUser?.id
-            adapter = MessageAdapter(getSelfMatches(userId!!), currentPearId) {
-                container.addChatFragment(userId!!, it.id, it.firstName, it.profilePicUrl!!)
+            if (currentPearId != null) {
+                adapter = MessageAdapter(getSelfMatches(userId!!), currentPearId) {
+                    container.addChatFragment(userId!!, it.id, it.firstName, it.profilePicUrl!!)
+                }
+                recyclerView.adapter = adapter
+                recyclerView.layoutManager = LinearLayoutManager(requireContext())
+            } else {
+                emptyMessagesView.visibility = View.VISIBLE
             }
-            recyclerView.adapter = adapter
-            recyclerView.layoutManager = LinearLayoutManager(requireContext())
         }
     }
 

--- a/app/src/main/res/layout/fragment_messages.xml
+++ b/app/src/main/res/layout/fragment_messages.xml
@@ -6,6 +6,41 @@
     android:layout_height="match_parent"
     tools:context=".fragments.messaging.MessagesFragment">
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/emptyMessagesView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="293dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/no_match_margin_vertical"
+            android:fontFamily="@font/circular_book"
+            android:gravity="center"
+            android:text="@string/no_match_to_message"
+            android:textColor="@color/faded_text"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/pear_logo"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/pear_logo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_sign_in_logo"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"
         android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,9 @@
     <string name="facebook_profile">Facebook profile link</string>
 
     <!--MESSAGING-->
+    <string name="no_match_to_message">
+        No pears to message right now.\nIn the meantime, browse the people\npage to see who else is on the app!
+    </string>
     <string name="send_message">\tSend a Message</string>
     <string name="send_message_hint">Say hi</string>
     <string name="messages_header">Messages</string>


### PR DESCRIPTION
## Overview
Fix a crash on clicking the messaging item in sidebar and stop users from sending empty chat messages.

## Changes Made
- Check if a user has any pears to message before making a networking call to prevent a crash for users with no pears
- Add an empty state to be displayed when user does not have a match
- Stop users from accidentally sending empty chat messages

## Test Coverage
Play-tested on Samsung S9.

## Screenshots

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>MessagingFragment</summary>
  <p>
    <img src="https://user-images.githubusercontent.com/19438967/160735265-4fd88bda-27a9-4f95-8aab-3068a61009af.jpg" width="350" height="700"/>
    <img src="https://user-images.githubusercontent.com/19438967/160735349-d58675e8-8636-4fa7-a505-ce30b598d8f0.jpg" width="350" height="700" />
  </p>


  

</details>
