### PR TITLE
Use library to pick and crop images

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,10 @@ android {
 }
 
 dependencies {
+    // image cropping and compression
+    api 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
+    implementation 'id.zelory:compressor:3.0.1'
+
     // Firebase messaging
     implementation platform('com.google.firebase:firebase-bom:28.4.2')
     implementation 'com.google.firebase:firebase-database-ktx:20.0.2'
@@ -67,7 +71,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    
+
     // Glide- image loading library
     implementation 'com.github.bumptech.glide:glide:4.12.0'
     // Glide v4 uses this new annotation processor -- see https://bumptech.github.io/glide/doc/generatedapi.html

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,4 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class androidx.appcompat.widget.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.cornellappdev.coffee_chats_android">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <queries>
         <intent>
             <action android:name="android.intent.action.PICK" />
@@ -16,6 +19,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+        <activity
+            android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:theme="@style/Base.Theme.AppCompat" />
         <activity
             android:name=".ProfileActivity"
             android:exported="false" />

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
@@ -273,15 +273,13 @@ class EditProfileFragment : Fragment(), OnFilledOutObservable {
         val hometown = hometownEditText.text.toString()
 
         CoroutineScope(Dispatchers.IO).launch {
-            val photoUrl = bitmap?.let {
-                return@let updateProfilePic(it)?.data
-            }
+            bitmap?.let { updateProfilePic(it) }
             val demographics = Demographics(
                 pronouns,
                 graduationYear,
                 if (majorIndex != null) listOf(majorIndex) else emptyList(),
                 hometown,
-                photoUrl
+                null
             )
             val updateDemographicsResponse = updateDemographics(demographics)
             if (updateDemographicsResponse == null || !updateDemographicsResponse.success) {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
@@ -190,7 +190,7 @@ class EditProfileFragment : Fragment(), OnFilledOutObservable {
     private fun pickImage() {
         CropImage.activity()
             .setGuidelines(CropImageView.Guidelines.ON)
-            .setAspectRatio(1, 1) //You can skip this for free form aspect ratio)
+            .setAspectRatio(1, 1)
             .start(requireContext(), this)
     }
 

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/ProfilePicBase64.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/ProfilePicBase64.kt
@@ -1,9 +1,10 @@
 package com.cornellappdev.coffee_chats_android.models
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ProfilePicBase64(
-    val image: String,
-    val bucket: String = "pear"
+    @Json(name = "profile_pic_base64")
+    val image: String
 )

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/networking/UserEndpoints.kt
@@ -3,7 +3,6 @@ package com.cornellappdev.coffee_chats_android.networking
 import android.graphics.Bitmap
 import android.util.Base64
 import android.util.Log
-import com.cornellappdev.coffee_chats_android.BuildConfig
 import com.cornellappdev.coffee_chats_android.models.*
 import com.google.gson.Gson
 import com.squareup.moshi.Moshi
@@ -81,11 +80,10 @@ fun Endpoint.Companion.updateProfilePic(bitmap: Bitmap): Endpoint {
     val profilePicStr = "data:image/png;base64,${bitmapToBase64String(bitmap)}"
     val requestBody = toRequestBody(ProfilePicBase64(profilePicStr), ProfilePicBase64::class.java)
     return Endpoint(
-        path = "${BuildConfig.PHOTO_SERVER_URI}/upload/",
+        path = "/me/",
         headers = authHeader(),
         body = requestBody,
-        method = EndpointMethod.POST,
-        useDefaultHost = false
+        method = EndpointMethod.POST
     )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,6 +262,9 @@
     <string name="edit_interests">Edit Interests</string>
     <string name="edit_groups">Edit Groups</string>
 
+    <string name="image_permission_denied">Permission denied. Please grant permissions to upload profile image.</string>
+    <string name="image_upload_failed">Failed to upload image.</string>
+
     <!--ABOUT-->
     <string name="pear_creation_reason">Pear was created to help Cornell students meet new people and form meaningful connections.</string>
     <string name="get_paired"><b>Get paired</b> up with a new Cornell student like you, every week.</string>


### PR DESCRIPTION
## Overview
Used image cropping and compression libraries to pick, crop, and compress images. This allows cropping even for images from apps without built-in cropping functionality. Big thanks to Jessie for sending me a very detailed code example for this!

Libraries
- [Android-Image-Cropper](https://github.com/ArthurHub/Android-Image-Cropper)
- [Compressor](https://github.com/zetbaitsu/Compressor)

## Changes Made
- Replace existing image upload logic with interactions with an image picking and cropping library
- Use an image compression library to compress the image
- Change image upload networking logic so we only send base64s to backend, and not the image upload library

## Test Coverage
Play-tested on Samsung S9 @ API 29.

## Next Steps
Remove lag between uploading an image and the new image showing up in the sidebar.

## Screenshots
See video recording in #pear-android.
