### PR TITLE
Change Spinner to EditText and fix UI bugs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation "androidx.fragment:fragment-ktx:1.3.1"
     implementation 'com.android.support.constraint:constraint-layout:2.0.4'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.3.4'

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -177,6 +177,7 @@ class SchedulingActivity : AppCompatActivity() {
     private fun signIn() {
         val intent = Intent(this, SignInActivity::class.java)
         startActivity(intent)
+        finish()
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.util.*
-import kotlin.collections.ArrayList
 
 class EditProfileFragment : Fragment(), OnFilledOutObservable {
     // variables to keep track if editTexts are filled out
@@ -106,22 +105,10 @@ class EditProfileFragment : Fragment(), OnFilledOutObservable {
             )
             majorACTV.setAdapter(majorAdapter)
 
-            // Initializing the pronoun spinner
-            val pronoun = arrayOf("He/Him/His", "She/Her/Hers", "They/Them/Theirs")
-            val pronounAdapter: ArrayAdapter<String> = ArrayAdapter(
-                requireContext(),
-                R.layout.profile_spinner_item,
-                pronoun
-            )
-            pronounSpinner.adapter = pronounAdapter
-            pronounSpinner.setSelection(
-                when (user.pronouns) {
-                    pronoun[0] -> 0
-                    pronoun[1] -> 1
-                    pronoun[2] -> 2
-                    else -> 0
-                }
-            )
+            // Initializing the pronoun EditText
+            if (!user.pronouns.isNullOrBlank()) {
+                pronounEditText.setText(user.pronouns)
+            }
         }
         upload_image.setOnClickListener {
             Intent(Intent.ACTION_PICK).apply {
@@ -192,7 +179,7 @@ class EditProfileFragment : Fragment(), OnFilledOutObservable {
     }
 
     override fun saveInformation() {
-        val pronouns = pronounSpinner.selectedItem as String
+        val pronouns = pronounEditText.text.toString()
         val graduationYear =
             if (classSpinner.selectedItem as String == gradStudent) gradStudent
             else (classSpinner.selectedItemPosition + year).toString()

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -89,15 +89,22 @@
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toBottomOf="@id/majorACTV" />
 
-        <Spinner
-            android:id="@+id/pronounSpinner"
+        <EditText
+            android:id="@+id/pronounEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="40dp"
             android:layout_marginTop="20dp"
             android:layout_marginRight="40dp"
             android:background="@drawable/rounded_edittext"
-            android:popupBackground="@color/white"
+            android:fontFamily="@font/circular_book"
+            android:hint="@string/pronouns"
+            android:imeOptions="actionDone"
+            android:padding="10dp"
+            android:singleLine="true"
+            android:textColor="@color/black"
+            android:textColorHint="@color/faded_text"
+            android:textSize="20sp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toBottomOf="@id/hometownEditText" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="upload_image">Upload New Picture</string>
     <string name="major">Major</string>
     <string name="hometown">Hometown</string>
+    <string name="pronouns">Pronouns</string>
     <string name="grad_student">Grad Student</string>
     <!--INTERESTS-->
     <string-array name="interest_titles">


### PR DESCRIPTION
## Overview
Changed pronouns from a `Spinner` to an `EditText` and fixed a bug where the tabs in `SchedulingActivity` would be blank after navigating from `OnboardingActivity`.

## Changes Made
- Modified `EditProfileFragment` and corresponding XML so that pronouns are entered via `EditText` instead of `Spinner`
- Finish `SchedulingActivity` after navigating to `SignInActivity` so that `onCreate` is called again when navigating from `OnboardingActivity` to `SchedulingActivity`- previously, the `onCreate` code was not called again, causing `SchedulingActivity` to present blank fragments in the `TabLayout`.

## Test Coverage
Play-tested on Samsung S9 @ API 29.

## Screenshots

<details>

  <summary>Pronouns EditText</summary>

https://user-images.githubusercontent.com/19438967/163688217-288b5ad6-edbe-42b9-b3f5-28112e8b3661.mp4  

</details>

<details>

  <summary>Non-blank SchedulingActivity After Onboarding</summary>

https://user-images.githubusercontent.com/19438967/163688247-00a6c8cd-9793-44ee-9853-8fd508807f5f.mp4

</details>
