### PR TITLE
[Profile Redesign][1/X] Start UI changes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <queries>
         <intent>
             <action android:name="android.intent.action.PICK" />
+
             <data android:mimeType="images/*" />
         </intent>
     </queries>
@@ -20,6 +21,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+        <activity
+            android:name=".AddUserFieldActivity"
+            android:exported="false" />
+
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/surprised_pear" />
@@ -29,6 +34,7 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="@string/default_notification_channel_id" />
+
         <activity
             android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
             android:theme="@style/Base.Theme.AppCompat" />
@@ -55,9 +61,11 @@
             android:theme="@style/noAnimTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
         <service
             android:name=".MyFirebaseMessagingService"
             android:exported="false"

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ActivityHelper.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ActivityHelper.kt
@@ -2,6 +2,7 @@ package com.cornellappdev.coffee_chats_android
 
 import android.content.Context
 import android.graphics.Rect
+import android.util.TypedValue
 import android.view.TouchDelegate
 import android.view.View
 import android.view.inputmethod.InputMethodManager
@@ -103,3 +104,10 @@ fun hideKeyboard(context: Context, view: View) {
     val imm = context.getSystemService(AppCompatActivity.INPUT_METHOD_SERVICE) as InputMethodManager
     imm.hideSoftInputFromWindow(view.applicationWindowToken, 0)
 }
+
+/** Converts dimension from dp to pixels */
+fun dpToPixels(c: Context, dp: Int): Int =
+    TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        dp.toFloat(), c.resources.displayMetrics
+    ).toInt()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/AddUserFieldActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/AddUserFieldActivity.kt
@@ -1,0 +1,78 @@
+package com.cornellappdev.coffee_chats_android
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
+import com.cornellappdev.coffee_chats_android.fragments.EditProfileFragment
+import com.cornellappdev.coffee_chats_android.fragments.PromptsFragment
+import com.cornellappdev.coffee_chats_android.fragments.UserFieldFragment
+import com.cornellappdev.coffee_chats_android.models.UserField
+import kotlinx.android.synthetic.main.activity_add_user_field.*
+import kotlinx.android.synthetic.main.activity_add_user_field.fragmentContainer
+import kotlinx.android.synthetic.main.activity_onboarding.*
+
+class AddUserFieldActivity : AppCompatActivity(), OnFilledOutListener {
+
+    enum class Content {
+        INTEREST,
+        GROUP
+    }
+
+    private lateinit var content: Content
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_add_user_field)
+        content = intent.extras?.getSerializable(CONTENT) as Content
+        headerText.text = when (content) {
+            Content.INTEREST -> getString(R.string.add_interests)
+            Content.GROUP -> getString(R.string.add_groups)
+        }
+        backButton.setOnClickListener { onBackPressed() }
+        primaryActionButton.setOnClickListener {
+            val currFragment =
+                supportFragmentManager.findFragmentByTag(content.name) as OnFilledOutObservable
+            currFragment.saveInformation()
+            onBackPressed()
+        }
+        val category = when (content) {
+            Content.INTEREST -> UserField.Category.INTEREST
+            Content.GROUP -> UserField.Category.GROUP
+        }
+        val ft: FragmentTransaction = supportFragmentManager.beginTransaction()
+        ft.replace(
+            fragmentContainer.id,
+            UserFieldFragment.newInstance(
+                category,
+                useRepository = true,
+                hideSelectedFields = true
+            ),
+            content.name
+        )
+            .addToBackStack("ft")
+            .commit()
+    }
+
+    override fun onAttachFragment(fragment: Fragment) {
+        if (fragment is OnFilledOutObservable) {
+            fragment.setOnFilledOutListener(this)
+        }
+    }
+
+    override fun onBackPressed() {
+        finish()
+    }
+
+    override fun onFilledOut() {
+        primaryActionButton.isEnabled = true
+    }
+
+    override fun onSelectionEmpty() {
+        primaryActionButton.isEnabled = false
+    }
+
+    companion object {
+        const val CONTENT = "content"
+    }
+}

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/OnboardingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/OnboardingActivity.kt
@@ -70,7 +70,11 @@ class OnboardingActivity : AppCompatActivity(), OnFilledOutListener,
             }
             user = getUser()
             val ft: FragmentTransaction = supportFragmentManager.beginTransaction()
-            ft.replace(fragmentContainer.id, EditProfileFragment.newInstance(true), content.name)
+            ft.replace(
+                fragmentContainer.id,
+                EditProfileFragment.newInstance(isOnboarding = true),
+                content.name
+            )
                 .addToBackStack("ft")
                 .commit()
             setUpCurrentPage()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/OnboardingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/OnboardingActivity.kt
@@ -70,7 +70,7 @@ class OnboardingActivity : AppCompatActivity(), OnFilledOutListener,
             }
             user = getUser()
             val ft: FragmentTransaction = supportFragmentManager.beginTransaction()
-            ft.replace(fragmentContainer.id, EditProfileFragment(), content.name)
+            ft.replace(fragmentContainer.id, EditProfileFragment.newInstance(true), content.name)
                 .addToBackStack("ft")
                 .commit()
             setUpCurrentPage()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
@@ -8,7 +8,7 @@ import androidx.fragment.app.commit
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.cornellappdev.coffee_chats_android.fragments.*
 import com.cornellappdev.coffee_chats_android.networking.getUser
-import com.cornellappdev.coffee_chats_android.respositories.UserRepository
+import com.cornellappdev.coffee_chats_android.repositories.UserRepository
 import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.android.synthetic.main.activity_profile_settings.*
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
@@ -5,18 +5,22 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
 import com.cornellappdev.coffee_chats_android.fragments.ProfileFragment
-import kotlinx.android.synthetic.main.activity_onboarding.*
+import kotlinx.android.synthetic.main.activity_profile_settings.*
 
 class ProfileActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_onboarding)
+        setContentView(R.layout.activity_profile_settings)
         headerLayout.setPadding(0, 0, 0, headerLayout.paddingBottom / 4)
-        onboarding_next.visibility = View.GONE
-        add_later.visibility = View.GONE
-        increaseHitArea(back_button)
-        back_button.setOnClickListener { onBackPressed() }
+        increaseHitArea(backButton)
+        backButton.setOnClickListener { onBackPressed() }
+        headerText.text = intent.extras?.getString(HEADER_TEXT) ?: ""
+        intent.extras?.getBoolean(ENABLE_EDIT).let {
+            save_button.visibility = View.VISIBLE
+            save_button.text = getString(R.string.edit)
+        }
+
         supportFragmentManager.commit {
             setReorderingAllowed(true)
             replace(
@@ -28,5 +32,7 @@ class ProfileActivity : AppCompatActivity() {
 
     companion object {
         const val USER_ID = "USER_ID"
+        const val HEADER_TEXT = "HEADER_TEXT"
+        const val ENABLE_EDIT = "ENABLE_EDIT"
     }
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
@@ -34,7 +34,6 @@ class ProfileActivity : AppCompatActivity(), OnFilledOutListener {
         headerText.text = intent.extras?.getString(HEADER_TEXT) ?: ""
         intent.extras?.getBoolean(ENABLE_EDIT).let {
             save_button.visibility = View.VISIBLE
-            save_button.text = getString(R.string.edit)
             save_button.setOnClickListener {
                 when (state) {
                     State.PREVIEW -> {
@@ -71,6 +70,7 @@ class ProfileActivity : AppCompatActivity(), OnFilledOutListener {
     private fun setUpPage() {
         when (state) {
             State.PREVIEW -> {
+                save_button.text = getString(R.string.edit)
                 tabLayout.visibility = View.GONE
                 fragmentContainer.visibility = View.VISIBLE
                 supportFragmentManager.commit {
@@ -82,6 +82,7 @@ class ProfileActivity : AppCompatActivity(), OnFilledOutListener {
                 }
             }
             State.EDIT -> {
+                save_button.text = getString(R.string.save)
                 CoroutineScope(Dispatchers.Main).launch {
                     val user = getUser()
                     UserRepository.initializeUser(user)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
@@ -3,11 +3,14 @@ package com.cornellappdev.coffee_chats_android
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
-import com.cornellappdev.coffee_chats_android.fragments.ProfileFragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.cornellappdev.coffee_chats_android.fragments.*
+import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.android.synthetic.main.activity_profile_settings.*
 
-class ProfileActivity : AppCompatActivity() {
+class ProfileActivity : AppCompatActivity(), OnFilledOutListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,8 +22,15 @@ class ProfileActivity : AppCompatActivity() {
         intent.extras?.getBoolean(ENABLE_EDIT).let {
             save_button.visibility = View.VISIBLE
             save_button.text = getString(R.string.edit)
+            save_button.setOnClickListener {
+                tabLayout.visibility = View.VISIBLE
+                viewPager.adapter = ViewPagerAdapter(this)
+                TabLayoutMediator(tabLayout, viewPager) { _, _ -> }.attach()
+                fragmentContainer.visibility = View.GONE
+            }
         }
 
+        fragmentContainer.visibility = View.VISIBLE
         supportFragmentManager.commit {
             setReorderingAllowed(true)
             replace(
@@ -30,9 +40,42 @@ class ProfileActivity : AppCompatActivity() {
         }
     }
 
+    override fun onAttachFragment(fragment: Fragment) {
+        if (fragment is OnFilledOutObservable) {
+            fragment.setOnFilledOutListener(this)
+        }
+    }
+
+    // adapter for tabs
+    private inner class ViewPagerAdapter(activity: ProfileActivity) :
+        FragmentStateAdapter(activity) {
+        override fun getItemCount(): Int {
+            return NUM_FRAGMENTS
+        }
+
+        override fun createFragment(position: Int): Fragment {
+            return when (position) {
+                0 -> EditProfileFragment()
+                1 -> EditProfileFragment()
+                2 -> EditProfileFragment()
+                3 -> EditProfileFragment()
+                else -> throw IllegalStateException()
+            }
+        }
+    }
+
     companion object {
         const val USER_ID = "USER_ID"
         const val HEADER_TEXT = "HEADER_TEXT"
         const val ENABLE_EDIT = "ENABLE_EDIT"
+        const val NUM_FRAGMENTS = 4
+    }
+
+    override fun onFilledOut() {
+        // TODO: Implement
+    }
+
+    override fun onSelectionEmpty() {
+        // TODO: Implement
     }
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
@@ -106,10 +106,10 @@ class ProfileActivity : AppCompatActivity(), OnFilledOutListener {
 
         override fun createFragment(position: Int): Fragment {
             return when (position) {
-                0 -> EditProfileFragment()
+                0 -> EditProfileFragment.newInstance(isOnboarding = false)
                 1 -> EditInterestsGroupsFragment.newInstance(true)
                 2 -> EditInterestsGroupsFragment.newInstance(false)
-                3 -> EditProfileFragment()
+                3 -> EditProfileFragment() // TODO replace with PromptsFragment
                 else -> throw IllegalStateException()
             }
         }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileActivity.kt
@@ -56,8 +56,8 @@ class ProfileActivity : AppCompatActivity(), OnFilledOutListener {
         override fun createFragment(position: Int): Fragment {
             return when (position) {
                 0 -> EditProfileFragment()
-                1 -> EditProfileFragment()
-                2 -> EditProfileFragment()
+                1 -> EditInterestsGroupsFragment.newInstance(true)
+                2 -> EditInterestsGroupsFragment.newInstance(false)
                 3 -> EditProfileFragment()
                 else -> throw IllegalStateException()
             }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
@@ -59,7 +59,7 @@ class ProfileSettingsActivity : AppCompatActivity(), OnFilledOutListener, OnPaus
         content = intent.getSerializableExtra(CONTENT) as Content
         isPaused = intent.getBooleanExtra(IS_PAUSED, isPaused)
         val fragment: Fragment = when (content) {
-            Content.EDIT_INFO -> EditProfileFragment()
+            Content.EDIT_INFO -> EditProfileFragment.newInstance(false)
             Content.EDIT_INTERESTS -> EditInterestsGroupsFragment.newInstance(true)
             Content.EDIT_GROUPS -> EditInterestsGroupsFragment.newInstance(false)
             Content.SETTINGS -> SettingsFragment()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
@@ -18,7 +18,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
-import kotlinx.android.synthetic.main.activity_scheduling.*
+import kotlinx.android.synthetic.main.activity_profile_settings.*
 
 class ProfileSettingsActivity : AppCompatActivity(), OnFilledOutListener, OnPauseChangedListener {
     private val ft: FragmentTransaction = supportFragmentManager.beginTransaction()
@@ -55,7 +55,7 @@ class ProfileSettingsActivity : AppCompatActivity(), OnFilledOutListener, OnPaus
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_scheduling)
+        setContentView(R.layout.activity_profile_settings)
         content = intent.getSerializableExtra(CONTENT) as Content
         isPaused = intent.getBooleanExtra(IS_PAUSED, isPaused)
         val fragment: Fragment = when (content) {
@@ -149,7 +149,7 @@ class ProfileSettingsActivity : AppCompatActivity(), OnFilledOutListener, OnPaus
                 )
                 background.showAtLocation(headerText, Gravity.CENTER, 0, 0)
                 // pause pear popup
-                val popupView = inflater.inflate(R.layout.pause_pear_popup, drawerLayout, false)
+                val popupView = inflater.inflate(R.layout.pause_pear_popup, activity_main, false)
                 popup = PopupWindow(
                     popupView,
                     ConstraintLayout.LayoutParams.WRAP_CONTENT,

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/ProfileSettingsActivity.kt
@@ -59,7 +59,7 @@ class ProfileSettingsActivity : AppCompatActivity(), OnFilledOutListener, OnPaus
         content = intent.getSerializableExtra(CONTENT) as Content
         isPaused = intent.getBooleanExtra(IS_PAUSED, isPaused)
         val fragment: Fragment = when (content) {
-            Content.EDIT_INFO -> EditProfileFragment.newInstance(false)
+            Content.EDIT_INFO -> EditProfileFragment.newInstance(isOnboarding = false)
             Content.EDIT_INTERESTS -> EditInterestsGroupsFragment.newInstance(true)
             Content.EDIT_GROUPS -> EditInterestsGroupsFragment.newInstance(false)
             Content.SETTINGS -> SettingsFragment()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -2,11 +2,9 @@ package com.cornellappdev.coffee_chats_android
 
 import android.app.Activity
 import android.content.Intent
-import android.content.res.Resources
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
-import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.MenuInflater
 import android.view.View
@@ -250,12 +248,10 @@ class SchedulingActivity :
     }
 
     private fun setUpCurrentPage() {
-        val displayMetrics = Resources.getSystem().displayMetrics
         // clear back caret icon
         backButton.background = null
         backButton.layoutParams = backButton.layoutParams.apply {
-            height = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30f, displayMetrics)
-                .toInt()
+            height = dpToPixels(this@SchedulingActivity, 30)
             width = height
         }
         increaseHitArea(backButton)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -124,8 +124,7 @@ class SchedulingActivity :
             drawerLayout.close()
             val intent = Intent(this, ProfileSettingsActivity::class.java)
             val contentTag = when (menuItem.itemId) {
-                R.id.nav_interests -> ProfileSettingsActivity.Content.EDIT_INTERESTS
-                R.id.nav_groups -> ProfileSettingsActivity.Content.EDIT_GROUPS
+                R.id.nav_profile -> throw NotImplementedError()
                 R.id.nav_settings -> ProfileSettingsActivity.Content.SETTINGS
                 else -> null
             }
@@ -133,7 +132,7 @@ class SchedulingActivity :
             intent.putExtra(ProfileSettingsActivity.IS_PAUSED, user.isPaused)
             when (menuItem.itemId) {
                 R.id.nav_settings -> startActivityForResult(intent, SETTINGS_CODE)
-                R.id.nav_interests, R.id.nav_groups -> startActivity(intent)
+                R.id.nav_profile -> throw NotImplementedError()
                 R.id.nav_messages -> {
                     val messagingIntent = Intent(this, MessagingActivity::class.java).apply {
                         putExtra(MessagingActivity.STAGE, MessagingActivity.Stage.MESSAGES)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -177,12 +177,6 @@ class SchedulingActivity :
         )
         drawerLayout.user_hometown.text = getString(R.string.user_hometown, user.hometown)
         val content = findViewById<ConstraintLayout>(R.id.activity_main)
-        drawerLayout.edit_info.setOnClickListener {
-            Intent(this, ProfileSettingsActivity::class.java).apply {
-                putExtra(ProfileSettingsActivity.CONTENT, ProfileSettingsActivity.Content.EDIT_INFO)
-                startActivity(this)
-            }
-        }
         drawerLayout.addDrawerListener(object : ActionBarDrawerToggle(
                 this,
                 drawerLayout,

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/SchedulingActivity.kt
@@ -124,7 +124,6 @@ class SchedulingActivity :
             drawerLayout.close()
             val intent = Intent(this, ProfileSettingsActivity::class.java)
             val contentTag = when (menuItem.itemId) {
-                R.id.nav_profile -> throw NotImplementedError()
                 R.id.nav_settings -> ProfileSettingsActivity.Content.SETTINGS
                 else -> null
             }
@@ -132,7 +131,15 @@ class SchedulingActivity :
             intent.putExtra(ProfileSettingsActivity.IS_PAUSED, user.isPaused)
             when (menuItem.itemId) {
                 R.id.nav_settings -> startActivityForResult(intent, SETTINGS_CODE)
-                R.id.nav_profile -> throw NotImplementedError()
+                R.id.nav_profile -> {
+                    val profileIntent = Intent(this, ProfileActivity::class.java)
+                    profileIntent.apply {
+                        putExtra(ProfileActivity.USER_ID, user.id)
+                        putExtra(ProfileActivity.HEADER_TEXT, getString(R.string.preview))
+                        putExtra(ProfileActivity.ENABLE_EDIT, true)
+                    }
+                    startActivity(profileIntent)
+                }
                 R.id.nav_messages -> {
                     val messagingIntent = Intent(this, MessagingActivity::class.java).apply {
                         putExtra(MessagingActivity.STAGE, MessagingActivity.Stage.MESSAGES)

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/adapters/UserFieldAdapter.kt
@@ -18,7 +18,9 @@ class UserFieldAdapter(
     private val fieldList: List<UserField>,
     private val itemColor: ItemColor,
     private val hideIcon: Boolean = true,
-    private val resizeCell: Boolean = false
+    private val resizeCell: Boolean = false,
+    private val showDeleteIcon: Boolean = false,
+    private val onDeleteClickListener: (Int) -> Unit = {}
 ) :
     ArrayAdapter<UserField?>(mContext, 0, fieldList), Filterable {
 
@@ -71,6 +73,11 @@ class UserFieldAdapter(
             viewHolder.icon.visibility = View.GONE
         }
 
+        if (showDeleteIcon) {
+            viewHolder.deleteIcon?.visibility = View.VISIBLE
+            viewHolder.deleteIcon?.setOnClickListener { onDeleteClickListener(position) }
+        }
+
         val selected = ContextCompat.getColor(context, R.color.onboardingListSelected)
         val unselected = ContextCompat.getColor(context, R.color.onboarding_fields)
         val drawableBox = viewHolder.layout!!.background
@@ -89,5 +96,6 @@ class UserFieldAdapter(
         val clubOrInterestSubtext = view?.findViewById(R.id.group_or_interest_subtext) as TextView
         val layout = view?.findViewById<ConstraintLayout>(R.id.group_or_interest_box)
         val icon = view?.findViewById<ImageView>(R.id.rounded_rectangle)
+        val deleteIcon = view?.findViewById<ImageView>(R.id.delete_icon)
     }
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
@@ -13,7 +13,7 @@ import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter.ItemColor
 import com.cornellappdev.coffee_chats_android.models.UserField
 import com.cornellappdev.coffee_chats_android.models.UserField.Category
-import com.cornellappdev.coffee_chats_android.respositories.UserRepository
+import com.cornellappdev.coffee_chats_android.repositories.UserRepository
 import kotlinx.android.synthetic.main.fragment_edit_interests.*
 import kotlinx.android.synthetic.main.fragment_edit_interests.view.*
 import kotlinx.android.synthetic.main.interest_group_list_with_header.view.*

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
@@ -53,8 +53,8 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         selected_items.list_title.text =
             getString(if (isInterest) R.string.menu_interests else R.string.menu_groups)
-        more_items.list_title.text = getString(R.string.more_items, itemString)
-        more_items.list_subtitle.text = getString(R.string.tap_to_add)
+        add_item_button.text =
+            getString(if (isInterest) R.string.add_interests else R.string.add_groups)
 
         CoroutineScope(Dispatchers.Main).launch {
             val user = getUser()
@@ -88,20 +88,18 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
             }
 
             selectedItemsAdapter =
-                UserFieldAdapter(requireContext(), selectedItems, ItemColor.GREEN, false)
+                UserFieldAdapter(
+                    requireContext(),
+                    selectedItems,
+                    ItemColor.WHITE,
+                    hideIcon = false,
+                    showDeleteIcon = true,
+                    onDeleteClickListener = { pos: Int -> moveItem(pos, selectedItems, moreItems) }
+                )
             selected_items.item_list.adapter = selectedItemsAdapter
-            moreItemsAdapter =
-                UserFieldAdapter(requireContext(), moreItems, ItemColor.WHITE, false)
-            more_items.item_list.adapter = moreItemsAdapter
             view_other_items.setOnClickListener {
                 showExcessSelectedItems = !showExcessSelectedItems
                 updatePage()
-            }
-            selected_items.item_list.setOnItemClickListener { _, _, position, _ ->
-                moveItem(position, selectedItems, moreItems)
-            }
-            more_items.item_list.setOnItemClickListener { _, _, position, _ ->
-                moveItem(position, moreItems, selectedItems)
             }
             toggleSaveButton()
             updatePage()
@@ -127,7 +125,6 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
         val numItemsShown =
             if (showExcessSelectedItems) selectedItems.size else min(selectedItems.size, 3)
         updateListViewHeight(selected_items.item_list, numItemsShown)
-        updateListViewHeight(more_items.item_list, moreItems.size)
     }
 
     /**
@@ -157,7 +154,6 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
         val index = max(dest.indexOfLast { i -> i.getText() < item.getText() } + 1, 0)
         dest.add(index, item)
         selectedItemsAdapter.notifyDataSetChanged()
-        moreItemsAdapter.notifyDataSetChanged()
         toggleSaveButton()
         updatePage()
     }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
@@ -1,17 +1,13 @@
 package com.cornellappdev.coffee_chats_android.fragments
 
-import android.content.res.Resources
 import android.os.Bundle
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ListView
 import androidx.fragment.app.Fragment
-import com.cornellappdev.coffee_chats_android.OnFilledOutListener
-import com.cornellappdev.coffee_chats_android.OnFilledOutObservable
-import com.cornellappdev.coffee_chats_android.R
+import com.cornellappdev.coffee_chats_android.*
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter.ItemColor
 import com.cornellappdev.coffee_chats_android.models.UserField
@@ -19,7 +15,6 @@ import com.cornellappdev.coffee_chats_android.models.UserField.Category
 import com.cornellappdev.coffee_chats_android.networking.getAllGroups
 import com.cornellappdev.coffee_chats_android.networking.getAllInterests
 import com.cornellappdev.coffee_chats_android.networking.getUser
-import com.cornellappdev.coffee_chats_android.updateUserField
 import kotlinx.android.synthetic.main.fragment_edit_interests.*
 import kotlinx.android.synthetic.main.fragment_edit_interests.view.*
 import kotlinx.android.synthetic.main.interest_group_list_with_header.view.*
@@ -67,7 +62,12 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
                 val userInterests = user.interests
                 val allInterests = getAllInterests()
                 for (interest in allInterests) {
-                    val item = UserField(interest.name, interest.subtitle, interest.imageUrl, id = interest.id)
+                    val item = UserField(
+                        interest.name,
+                        interest.subtitle,
+                        interest.imageUrl,
+                        id = interest.id
+                    )
                     if (interest in userInterests) {
                         selectedItems.add(item)
                     } else {
@@ -136,10 +136,7 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
      */
     private fun updateListViewHeight(listView: ListView, listSize: Int) {
         listView.layoutParams = (listView.layoutParams as LinearLayout.LayoutParams).apply {
-            val displayMetrics = Resources.getSystem().displayMetrics
-            val cellHeight =
-                TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 80f, displayMetrics).toInt()
-
+            val cellHeight = dpToPixels(requireContext(), 80)
             height = cellHeight * listSize
             listView.requestLayout()
             scrollView.requestLayout()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditInterestsGroupsFragment.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.coffee_chats_android.fragments
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -12,25 +13,17 @@ import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter
 import com.cornellappdev.coffee_chats_android.adapters.UserFieldAdapter.ItemColor
 import com.cornellappdev.coffee_chats_android.models.UserField
 import com.cornellappdev.coffee_chats_android.models.UserField.Category
-import com.cornellappdev.coffee_chats_android.networking.getAllGroups
-import com.cornellappdev.coffee_chats_android.networking.getAllInterests
-import com.cornellappdev.coffee_chats_android.networking.getUser
+import com.cornellappdev.coffee_chats_android.respositories.UserRepository
 import kotlinx.android.synthetic.main.fragment_edit_interests.*
 import kotlinx.android.synthetic.main.fragment_edit_interests.view.*
 import kotlinx.android.synthetic.main.interest_group_list_with_header.view.*
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlin.math.max
 import kotlin.math.min
 
 class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
     private var isInterest = true
     private lateinit var itemString: String
     private val selectedItems = ArrayList<UserField>()
-    private val moreItems = ArrayList<UserField>()
     private lateinit var selectedItemsAdapter: UserFieldAdapter
-    private lateinit var moreItemsAdapter: UserFieldAdapter
 
     /** whether to display all selected items, or just the first 3 */
     private var showExcessSelectedItems = false
@@ -55,55 +48,55 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
             getString(if (isInterest) R.string.menu_interests else R.string.menu_groups)
         add_item_button.text =
             getString(if (isInterest) R.string.add_interests else R.string.add_groups)
-
-        CoroutineScope(Dispatchers.Main).launch {
-            val user = getUser()
-            if (isInterest) {
-                val userInterests = user.interests
-                val allInterests = getAllInterests()
-                for (interest in allInterests) {
-                    val item = UserField(
-                        interest.name,
-                        interest.subtitle,
-                        interest.imageUrl,
-                        id = interest.id
-                    )
-                    if (interest in userInterests) {
-                        selectedItems.add(item)
-                    } else {
-                        moreItems.add(item)
-                    }
-                }
-            } else {
-                val userGroups = user.groups
-                val allGroups = getAllGroups()
-                for (group in allGroups) {
-                    val item = UserField(group.name, drawableUrl = group.imageUrl, id = group.id)
-                    if (group in userGroups) {
-                        selectedItems.add(item)
-                    } else {
-                        moreItems.add(item)
-                    }
-                }
-            }
-
-            selectedItemsAdapter =
-                UserFieldAdapter(
-                    requireContext(),
-                    selectedItems,
-                    ItemColor.WHITE,
-                    hideIcon = false,
-                    showDeleteIcon = true,
-                    onDeleteClickListener = { pos: Int -> moveItem(pos, selectedItems, moreItems) }
+        add_item_button.setOnClickListener {
+            val intent = Intent(context, AddUserFieldActivity::class.java).apply {
+                putExtra(
+                    AddUserFieldActivity.CONTENT,
+                    if (isInterest) AddUserFieldActivity.Content.INTEREST else AddUserFieldActivity.Content.GROUP
                 )
-            selected_items.item_list.adapter = selectedItemsAdapter
-            view_other_items.setOnClickListener {
-                showExcessSelectedItems = !showExcessSelectedItems
-                updatePage()
             }
-            toggleSaveButton()
+            startActivity(intent)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        selectedItems.clear()
+        if (isInterest) {
+            val userInterests = UserRepository.user.interests
+            for (interest in userInterests) {
+                val item = UserField(
+                    interest.name,
+                    interest.subtitle,
+                    interest.imageUrl,
+                    id = interest.id
+                )
+                selectedItems.add(item)
+            }
+        } else {
+            val userGroups = UserRepository.user.groups
+            for (group in userGroups) {
+                val item = UserField(group.name, drawableUrl = group.imageUrl, id = group.id)
+                selectedItems.add(item)
+            }
+        }
+
+        selectedItemsAdapter =
+            UserFieldAdapter(
+                requireContext(),
+                selectedItems,
+                ItemColor.WHITE,
+                hideIcon = false,
+                showDeleteIcon = true,
+                onDeleteClickListener = { pos: Int -> removeItem(pos) }
+            )
+        selected_items.item_list.adapter = selectedItemsAdapter
+        view_other_items.setOnClickListener {
+            showExcessSelectedItems = !showExcessSelectedItems
             updatePage()
         }
+        toggleSaveButton()
+        updatePage()
     }
 
     private fun updatePage() {
@@ -141,18 +134,16 @@ class EditInterestsGroupsFragment : Fragment(), OnFilledOutObservable {
     }
 
     /**
-     * Moves item at position `pos` in `source` to `dest`, ensuring that items are sorted in
-     * alphabetical order, then updates the page to reflect changes
+     * Removes item at position `pos` in `selectedItems`, saves changes to the repository, then
+     * updates the page to reflect changes
      */
-    private fun moveItem(
-        pos: Int,
-        source: ArrayList<UserField>,
-        dest: ArrayList<UserField>
-    ) {
-        val item = source.removeAt(pos)
-        // find insertion index that preserves alphabetical order
-        val index = max(dest.indexOfLast { i -> i.getText() < item.getText() } + 1, 0)
-        dest.add(index, item)
+    private fun removeItem(pos: Int) {
+        val removedItemId = selectedItems.removeAt(pos).id
+        if (isInterest) {
+            UserRepository.removeInterest(removedItemId)
+        } else {
+            UserRepository.removeGroup(removedItemId)
+        }
         selectedItemsAdapter.notifyDataSetChanged()
         toggleSaveButton()
         updatePage()

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/EditProfileFragment.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat.checkSelfPermission
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -22,6 +23,7 @@ import com.bumptech.glide.Glide
 import com.cornellappdev.coffee_chats_android.OnFilledOutListener
 import com.cornellappdev.coffee_chats_android.OnFilledOutObservable
 import com.cornellappdev.coffee_chats_android.R
+import com.cornellappdev.coffee_chats_android.dpToPixels
 import com.cornellappdev.coffee_chats_android.models.Demographics
 import com.cornellappdev.coffee_chats_android.models.Major
 import com.cornellappdev.coffee_chats_android.models.User
@@ -55,6 +57,15 @@ class EditProfileFragment : Fragment(), OnFilledOutObservable {
 
     private lateinit var allMajorsList: List<Major>
 
+    private var isOnboarding = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            isOnboarding = it.getBoolean(IS_ONBOARDING)
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -85,6 +96,21 @@ class EditProfileFragment : Fragment(), OnFilledOutObservable {
             if (!user.profilePicUrl.isNullOrBlank()) {
                 Glide.with(requireContext()).load(user.profilePicUrl).centerInside().circleCrop()
                     .into(user_image)
+            }
+
+            if (isOnboarding) {
+                val layoutParams = classSpinner.layoutParams as ConstraintLayout.LayoutParams
+                layoutParams.setMargins(
+                    layoutParams.leftMargin,
+                    dpToPixels(requireContext(), 50),
+                    layoutParams.rightMargin,
+                    0
+                )
+                nameEditText.visibility = View.GONE
+                classSpinner.layoutParams = layoutParams
+            } else {
+                val name = getString(R.string.user_name, user.firstName, user.lastName)
+                nameEditText.setText(name)
             }
 
             if (!user.hometown.isNullOrBlank()) {
@@ -278,5 +304,14 @@ class EditProfileFragment : Fragment(), OnFilledOutObservable {
 
     companion object {
         private const val PICK_IMAGE_CODE = 42
+        private const val IS_ONBOARDING = "IS_ONBOARDING"
+
+        @JvmStatic
+        fun newInstance(isOnboarding: Boolean = false) =
+            EditProfileFragment().apply {
+                arguments = Bundle().apply {
+                    putBoolean(IS_ONBOARDING, isOnboarding)
+                }
+            }
     }
 }

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/ProfileFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/ProfileFragment.kt
@@ -74,7 +74,6 @@ class ProfileFragment : Fragment() {
         Glide.with(c).load(user.profilePicUrl).centerInside().circleCrop()
             .into(userImage)
         name.text = c.getString(R.string.user_name, user.firstName, user.lastName)
-        reach_me.text = c.getString(R.string.reach_me, user.netId)
         val basicInfo = c.getString(
             R.string.basic_profile_info,
             user.majors.first().name, user.graduationYear, user.hometown, user.pronouns

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/UserFieldFragment.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/fragments/UserFieldFragment.kt
@@ -24,7 +24,7 @@ import com.cornellappdev.coffee_chats_android.networking.getAllGroups
 import com.cornellappdev.coffee_chats_android.networking.getAllInterests
 import com.cornellappdev.coffee_chats_android.networking.getAllPurposes
 import com.cornellappdev.coffee_chats_android.networking.getUser
-import com.cornellappdev.coffee_chats_android.respositories.UserRepository
+import com.cornellappdev.coffee_chats_android.repositories.UserRepository
 import com.cornellappdev.coffee_chats_android.updateUserField
 import kotlinx.android.synthetic.main.fragment_interests_groups.*
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/models/User.kt
@@ -45,4 +45,33 @@ data class User(
     val isPaused: Boolean,
     @Json(name = "pause_expiration")
     val pauseExpiration: String?
-)
+) {
+    companion object {
+        val DUMMY_USER = User(
+            id = -1,
+            netId = "dummy",
+            firstName = "Dummy",
+            lastName = "User",
+            hometown = "Vale",
+            profilePicUrl = null,
+            facebookUrl = null,
+            instagramUsername = null,
+            majors = ArrayList(),
+            graduationYear = "2023",
+            pronouns = null,
+            prompts = ArrayList(),
+            purposes = ArrayList(),
+            goals = ArrayList(),
+            talkingPoints = null,
+            availability = null,
+            locations = ArrayList(),
+            interests = ArrayList(),
+            groups = ArrayList(),
+            hasOnboarded = true,
+            pendingFeedback = false,
+            currentMatch = null,
+            isPaused = false,
+            pauseExpiration = null,
+        )
+    }
+}

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/repositories/UserRepository.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/repositories/UserRepository.kt
@@ -1,4 +1,4 @@
-package com.cornellappdev.coffee_chats_android.respositories
+package com.cornellappdev.coffee_chats_android.repositories
 
 import com.cornellappdev.coffee_chats_android.models.Group
 import com.cornellappdev.coffee_chats_android.models.Interest

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/respositories/UserRepository.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/respositories/UserRepository.kt
@@ -1,0 +1,55 @@
+package com.cornellappdev.coffee_chats_android.respositories
+
+import com.cornellappdev.coffee_chats_android.models.Group
+import com.cornellappdev.coffee_chats_android.models.Interest
+import com.cornellappdev.coffee_chats_android.models.User
+import java.lang.Integer.max
+
+/**
+ * Singleton class for storing user info when editing profile
+ */
+object UserRepository {
+    var user = User.DUMMY_USER
+        private set
+
+    fun initializeUser(userInfo: User) {
+        user = userInfo
+    }
+
+    fun removeInterest(interestId: Int) {
+        val interests = ArrayList<Interest>(user.interests).filter { it.id != interestId }
+        user = user.copy(interests = interests)
+    }
+
+    fun removeGroup(groupId: Int) {
+        val groups = ArrayList<Group>(user.groups).filter { it.id != groupId }
+        user = user.copy(groups = groups)
+    }
+
+    fun addInterest(interest: Interest) {
+        val interests = ArrayList<Interest>(user.interests)
+        if (interests.contains(interest)) {
+            return
+        }
+        // find insertion index that preserves alphabetical order
+        val index = max(interests.indexOfLast { it.name < interest.name } + 1, 0)
+        interests.add(index, interest)
+        user = user.copy(interests = interests)
+    }
+
+    fun addGroup(group: Group) {
+        val groups = ArrayList<Group>(user.groups)
+        if (groups.contains(group)) {
+            return
+        }
+        // find insertion index that preserves alphabetical order
+        val index = max(groups.indexOfLast { it.name < group.name } + 1, 0)
+        groups.add(index, group)
+        user = user.copy(groups = groups)
+    }
+
+    /** Saves user information to backend */
+    fun saveUserInfo() {
+        TODO()
+    }
+}

--- a/app/src/main/java/com/cornellappdev/coffee_chats_android/utils/PopupManager.kt
+++ b/app/src/main/java/com/cornellappdev/coffee_chats_android/utils/PopupManager.kt
@@ -1,13 +1,12 @@
 package com.cornellappdev.coffee_chats_android.utils
 
 import android.content.Context
-import android.util.Log
-import android.util.TypedValue
 import android.view.View
 import android.widget.PopupWindow
 import android.widget.RadioButton
 import com.cornellappdev.coffee_chats_android.OnPauseChangedListener
 import com.cornellappdev.coffee_chats_android.R
+import com.cornellappdev.coffee_chats_android.dpToPixels
 import com.cornellappdev.coffee_chats_android.networking.updatePauseStatus
 import kotlinx.android.synthetic.main.pause_pear_popup.view.*
 import kotlinx.coroutines.CoroutineScope
@@ -122,7 +121,7 @@ class PopupManager(
 
         v.popup_title.visibility = View.VISIBLE
         v.radio_group.visibility = View.VISIBLE
-        v.radio_group.layoutParams.width = dpToPixels(radioGroupWidth)
+        v.radio_group.layoutParams.width = dpToPixels(c, radioGroupWidth)
         v.radio_group.clearCheck()
         val buttonLabels = c.resources.getStringArray(buttonsStringArrayId)
         for (i in radioButtons.indices) {
@@ -132,13 +131,6 @@ class PopupManager(
             v.action_button.isEnabled = true
         }
     }
-
-    /** Converts dimension from dp to pixels */
-    private fun dpToPixels(dp: Int): Int =
-        TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_DIP,
-            dp.toFloat(), c.resources.displayMetrics
-        ).toInt()
 
     /**
      * Returns string corresponding to the current state

--- a/app/src/main/res/drawable/dot_default.xml
+++ b/app/src/main/res/drawable/dot_default.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape
+            android:innerRadius="0dp"
+            android:shape="ring"
+            android:thickness="4dp"
+            android:useLevel="false">
+            <solid android:color="#8099A899" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/dot_selected.xml
+++ b/app/src/main/res/drawable/dot_selected.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape
+            android:innerRadius="0dp"
+            android:shape="ring"
+            android:thickness="4dp"
+            android:useLevel="false">
+            <solid android:color="@color/forest_green" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/dot_selector.xml
+++ b/app/src/main/res/drawable/dot_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/dot_selected" android:state_selected="true" />
+    <item android:drawable="@drawable/dot_default" />
+</selector>

--- a/app/src/main/res/layout/activity_add_user_field.xml
+++ b/app/src/main/res/layout/activity_add_user_field.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_green"
+    tools:context=".AddUserFieldActivity">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/headerLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:paddingBottom="20dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/backButton"
+            android:layout_width="10dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/ic_back_carrot"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/headerText" />
+
+        <TextView
+            android:id="@+id/headerText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="45dp"
+            android:layout_marginEnd="45dp"
+            android:fontFamily="@font/circular_medium"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="24sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <FrameLayout
+        android:id="@+id/fragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/primaryActionButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/headerLayout" />
+
+    <Button
+        android:id="@+id/primaryActionButton"
+        style="?android:attr/borderlessButtonStyle"
+        android:layout_width="200dp"
+        android:layout_height="50dp"
+        android:layout_marginBottom="70dp"
+        android:background="@drawable/profile_button_background"
+        android:fontFamily="@font/circular_medium"
+        android:text="@string/save"
+        android:textAllCaps="false"
+        android:textColor="@color/white"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_profile_settings.xml
+++ b/app/src/main/res/layout/activity_profile_settings.xml
@@ -29,24 +29,6 @@
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.material.tabs.TabLayout
-            android:id="@+id/tabLayout"
-            android:layout_width="0dp"
-            android:layout_height="40dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginHorizontal="74dp"
-            android:background="@drawable/rounded_shape_white"
-            android:paddingHorizontal="@dimen/tab_padding_horizontal"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tabIndicatorColor="@color/transparent"
-            app:tabMode="fixed"
-            app:tabSelectedTextColor="@color/forest_green"
-            app:tabTextAppearance="@style/tabLayoutTheme"
-            app:tabTextColor="@color/secondary_green_grey" />
-
         <TextView
             android:id="@+id/headerText"
             android:layout_width="0dp"
@@ -95,8 +77,31 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginVertical="5dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/tabLayout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/headerLayout" />
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabLayout"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginHorizontal="74dp"
+        android:paddingHorizontal="@dimen/tab_padding_horizontal"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:tabBackground="@drawable/dot_selector"
+        app:tabGravity="center"
+        app:tabIndicatorColor="@color/transparent"
+        app:tabIndicatorHeight="0dp"
+        app:tabMode="fixed"
+        app:tabPaddingEnd="@dimen/dot_tab_padding"
+        app:tabPaddingStart="@dimen/dot_tab_padding"
+        app:tabSelectedTextColor="@color/forest_green"
+        app:tabTextAppearance="@style/tabLayoutTheme"
+        app:tabTextColor="@color/secondary_green_grey" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_profile_settings.xml
+++ b/app/src/main/res/layout/activity_profile_settings.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_green">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/headerLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="44dp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/backButton"
+            android:layout_width="10dp"
+            android:layout_height="20dp"
+            android:layout_marginStart="@dimen/default_border_margin"
+            android:background="@drawable/ic_back_carrot"
+            android:clickable="true"
+            android:focusable="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayout"
+            android:layout_width="0dp"
+            android:layout_height="40dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginHorizontal="74dp"
+            android:background="@drawable/rounded_shape_white"
+            android:paddingHorizontal="@dimen/tab_padding_horizontal"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tabIndicatorColor="@color/transparent"
+            app:tabMode="fixed"
+            app:tabSelectedTextColor="@color/forest_green"
+            app:tabTextAppearance="@style/tabLayoutTheme"
+            app:tabTextColor="@color/secondary_green_grey" />
+
+        <TextView
+            android:id="@+id/headerText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="70dp"
+            android:layout_marginRight="70dp"
+            android:fontFamily="@font/circular_medium"
+            android:gravity="center"
+            android:text="@string/no_match_header"
+            android:textColor="@color/black"
+            android:textSize="24sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/save_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@null"
+            android:enabled="true"
+            android:text="@string/save"
+            android:textAllCaps="false"
+            android:textColor="@color/save_button_text_color"
+            android:textSize="20sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPager"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="5dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/headerLayout" />
+
+    <FrameLayout
+        android:id="@+id/fragmentContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="5dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/headerLayout" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_edit_interests.xml
+++ b/app/src/main/res/layout/fragment_edit_interests.xml
@@ -64,7 +64,7 @@
                 android:textAlignment="viewStart"
                 android:textAllCaps="false"
                 android:textColor="@color/secondary_green_grey"
-                android:textSize="16sp"
+                android:textSize="20sp"
                 tools:text="@string/add_interests" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_edit_interests.xml
+++ b/app/src/main/res/layout/fragment_edit_interests.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -52,11 +53,19 @@
                     android:textSize="16sp" />
             </LinearLayout>
 
-            <include
-                android:id="@+id/more_items"
-                layout="@layout/interest_group_list_with_header"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+            <Button
+                android:id="@+id/add_item_button"
+                android:layout_width="300dp"
+                android:layout_height="68dp"
+                android:background="@drawable/rounded_edittext"
+                android:drawableStart="@drawable/ic_plus"
+                android:drawablePadding="20dp"
+                android:padding="20dp"
+                android:textAlignment="viewStart"
+                android:textAllCaps="false"
+                android:textColor="@color/secondary_green_grey"
+                android:textSize="16sp"
+                tools:text="@string/add_interests" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_edit_profile.xml
+++ b/app/src/main/res/layout/fragment_edit_profile.xml
@@ -39,17 +39,36 @@
             app:layout_constraintStart_toStartOf="@id/user_image"
             app:layout_constraintTop_toTopOf="@id/user_image" />
 
-        <Spinner
-            android:id="@+id/classSpinner"
+        <EditText
+            android:id="@+id/nameEditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginLeft="40dp"
             android:layout_marginTop="50dp"
             android:layout_marginRight="40dp"
             android:background="@drawable/rounded_edittext"
-            android:popupBackground="@color/white"
+            android:fontFamily="@font/circular_book"
+            android:hint="@string/name"
+            android:imeOptions="actionDone"
+            android:padding="10dp"
+            android:singleLine="true"
+            android:textColor="@color/black"
+            android:textColorHint="@color/faded_text"
+            android:textSize="20sp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toBottomOf="@id/user_image" />
+
+        <Spinner
+            android:id="@+id/classSpinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="40dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginRight="40dp"
+            android:background="@drawable/rounded_edittext"
+            android:popupBackground="@color/white"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/nameEditText" />
 
         <AutoCompleteTextView
             android:id="@+id/majorACTV"

--- a/app/src/main/res/layout/fragment_no_match.xml
+++ b/app/src/main/res/layout/fragment_no_match.xml
@@ -26,18 +26,20 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginTop="@dimen/no_match_image_margin_top"
+        android:layout_marginBottom="@dimen/no_match_margin_vertical"
         android:scaleType="fitCenter"
         android:src="@drawable/ic_surprised_pear"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/headerText" />
+        app:layout_constraintTop_toBottomOf="@id/headerText"
+        app:layout_constraintBottom_toTopOf="@id/primaryActionButton"/>
 
     <Button
         android:id="@+id/primaryActionButton"
         style="?android:attr/borderlessButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="50dp"
-        android:layout_marginTop="@dimen/no_match_margin_vertical"
+        android:layout_marginBottom="@dimen/no_match_button_margin_bottom"
         android:background="@drawable/profile_button_background"
         android:elevation="3dp"
         android:enabled="true"
@@ -50,13 +52,13 @@
         android:textSize="20sp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/no_match_image" />
+        app:layout_constraintBottom_toTopOf="@id/no_match_subheader" />
 
     <TextView
         android:id="@+id/no_match_subheader"
         android:layout_width="293dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/no_match_subheader_margin_top"
+        android:layout_marginBottom="@dimen/no_match_subheader_margin_bottom"
         android:fontFamily="@font/circular_book"
         android:gravity="center"
         android:text="@string/no_match_subheader"
@@ -65,6 +67,6 @@
         android:textStyle="bold"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/primaryActionButton" />
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -51,19 +51,6 @@
                 tools:text="@string/dummy_name" />
 
             <TextView
-                android:id="@+id/reach_me"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/circular_book"
-                android:gravity="center"
-                android:textColor="@color/faded_text"
-                android:textSize="14sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/name"
-                tools:text="Reach me at abc123" />
-
-            <TextView
                 android:id="@+id/basics_header"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -77,7 +64,7 @@
                 android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/reach_me" />
+                app:layout_constraintTop_toBottomOf="@id/name" />
 
             <TextView
                 android:id="@+id/basic_info"

--- a/app/src/main/res/layout/interest_group_list_with_header.xml
+++ b/app/src/main/res/layout/interest_group_list_with_header.xml
@@ -23,6 +23,7 @@
         android:fontFamily="@font/circular_book"
         android:textColor="@color/faded_text"
         android:textSize="12sp"
+        android:visibility="gone"
         tools:text="tap to deselect" />
 
     <ListView

--- a/app/src/main/res/layout/interest_view.xml
+++ b/app/src/main/res/layout/interest_view.xml
@@ -1,47 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/group_or_interest_box"
     android:layout_width="match_parent"
     android:layout_height="68dp"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@drawable/rounded_edittext">
 
 
-    <ImageView android:id="@+id/rounded_rectangle"
+    <ImageView
+        android:id="@+id/rounded_rectangle"
         android:layout_width="50dp"
         android:layout_height="50dp"
         android:layout_marginStart="8dp"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintStart_toEndOf="@id/rounded_rectangle"
-        app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginStart="10dp"
         android:layout_marginEnd="10dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/delete_icon"
+        app:layout_constraintStart_toEndOf="@id/rounded_rectangle"
+        app:layout_constraintTop_toTopOf="parent">
+
         <TextView
             android:id="@+id/group_or_interest_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="20sp"
+            android:fontFamily="@font/circular_book"
             android:textColor="@color/black"
-            android:fontFamily="@font/circular_book"/>
+            android:textSize="20sp" />
 
         <TextView
             android:id="@+id/group_or_interest_subtext"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fontFamily="@font/circular_book"
-            android:textSize="12sp"
             android:textColor="@color/faded_text"
+            android:textSize="12sp"
             app:layout_constraintStart_toStartOf="@id/group_or_interest_text"
-            app:layout_constraintTop_toBottomOf="@id/group_or_interest_text"/>
+            app:layout_constraintTop_toBottomOf="@id/group_or_interest_text" />
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/delete_icon"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_gravity="center_vertical"
+        android:layout_margin="10dp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_x_icon" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/nav_header_profile.xml
+++ b/app/src/main/res/layout/nav_header_profile.xml
@@ -26,25 +26,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:srcCompat="@mipmap/ic_launcher_round" />
-
-        <Button
-            android:id="@+id/edit_info"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="90dp"
-            android:layout_marginBottom="10dp"
-            android:background="@drawable/rounded_shape_white"
-            android:fontFamily="@font/circular_medium"
-            android:minWidth="0dp"
-            android:minHeight="0dp"
-            android:paddingHorizontal="12dp"
-            android:paddingVertical="8dp"
-            android:text="@string/edit_info"
-            android:textAllCaps="false"
-            android:textColor="@color/accent_orange"
-            android:textSize="12sp"
-            app:layout_constraintBottom_toBottomOf="@id/user_image"
-            app:layout_constraintStart_toStartOf="@id/user_image" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView

--- a/app/src/main/res/menu/activity_scheduling_drawer.xml
+++ b/app/src/main/res/menu/activity_scheduling_drawer.xml
@@ -6,14 +6,9 @@
 
     <group android:checkableBehavior="single">
         <item
-            android:id="@+id/nav_interests"
+            android:id="@+id/nav_profile"
             android:icon="@drawable/ic_interests_icon"
-            android:title="@string/menu_interests"
-            app:actionLayout="@layout/nav_drawer_item" />
-        <item
-            android:id="@+id/nav_groups"
-            android:icon="@drawable/ic_groups_icon"
-            android:title="@string/menu_groups"
+            android:title="@string/menu_profile"
             app:actionLayout="@layout/nav_drawer_item" />
         <item
             android:id="@+id/nav_messages"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="signInGrey">#EEEEEE</color>
     <color name="white">#FFFFFF</color>
     <color name="black">#000000</color>
+    <color name="light_secondary_green_grey">#8099A899</color>
     <color name="secondary_green_grey">#99A899</color>
     <color name="searchHint">#979797</color>
     <color name="faded_text">#5B7E58</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,6 +9,9 @@
     <dimen name="search_bar_height">40dp</dimen>
     <dimen name="tab_padding_horizontal">7dp</dimen>
 
+    <!-- ProfileActivity -->
+    <dimen name="dot_tab_padding">8dp</dimen>
+
     <!-- ProfileFragment -->
     <dimen name="profile_padding_bottom">110dp</dimen>
     <dimen name="profile_margin_vertical">20dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -18,8 +18,9 @@
 
     <!-- NoMatchFragment -->
     <dimen name="no_match_margin_vertical">40dp</dimen>
-    <dimen name="no_match_subheader_margin_top">12dp</dimen>
+    <dimen name="no_match_button_margin_bottom">12dp</dimen>
     <dimen name="no_match_image_margin_top">60dp</dimen>
+    <dimen name="no_match_subheader_margin_bottom">24dp</dimen>
 
     <!-- MESSAGING -->
     <dimen name="profile_pic_margin">15dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="talking_pointers_header">What do you most want to talk about?</string>
     <string name="add_later_button">I\'ll add later</string>
     <string name="upload_image">Upload New Picture</string>
+    <string name="name">Name</string>
     <string name="major">Major</string>
     <string name="hometown">Hometown</string>
     <string name="pronouns">Pronouns</string>
@@ -125,7 +126,6 @@
 
 
     <!--PROFILE-->
-    <string name="reach_me">Reach me at %1$s</string>
     <string name="basic_profile_info">I study &lt;b>%1$s&lt;/b> in the class of &lt;b>%2$s&lt;/b>, and my home is in &lt;b>%3$s&lt;/b>! My pronouns are &lt;b>%4$s&lt;/b>.</string>
     <string name="dummy_name">First Last</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,10 @@
         <item>road, trips, backpacking</item>
     </string-array>
 
+    <!--EDIT PROFILE-->
+    <string name="preview">Preview</string>
+    <string name="edit">Edit</string>
+
     <!--PROMPTS-->
     <string name="prompts_header">Let\'s get to know you better!</string>
     <string name="select_prompt">Select a prompt</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,6 +270,8 @@
     <string name="view_fewer">view fewer %1$s</string>
     <string name="select_one_interest">Select at least one interest so that we can better help you find a Pear!</string>
     <string name="select_one_group">Select a group so that we can better help you find a Pear!</string>
+    <string name="add_interests">Add interests</string>
+    <string name="add_groups">Add groups</string>
 
     <string name="edit_availability">Edit Availability</string>
     <string name="edit_interests">Edit Interests</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,6 +231,7 @@
     <string name="user_name">%1$s %2$s</string>
     <string name="user_hometown">From %1$s</string>
     <string name="user_major_year">%1$s %2$s</string>
+    <string name="menu_profile">Your profile</string>
     <string name="menu_groups">Your groups</string>
     <string name="menu_interests">Your interests</string>
     <string name="menu_prompts">Your prompts</string>

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10'
         classpath 'com.google.gms:google-services:4.3.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Overview
Profile redesign allows users to preview their current profile, and move into a unified editing experience with 4 sections: general info, interests, groups, prompts. 

This PR started the UI changes and refactoring for profile redesign by adding a profile preview, setting up a repository to persist local changes to user info across activities, and implementing the UI and navigation for the general info, interests, and groups sections. I was originally planning to complete profile redesign in one PR, but I realized it was starting to get too big, especially since I also did some refactoring, so I decided to stop before starting work on prompts.

## Changes Made
- Drawer
  - Removed "Your interests" and "Your groups" from the `DrawerLayout` menu, replacing them with the single menu item "Your profile"
  - Removed button next to profile pic that was previously used to edit general info in profile
- Refactoring/Better Engineering
  - Refactored `ProfileSettingsActivity` and `ProfileActivity` to use a shared XML layout file instead of using the XML of `SchedulingActivity`
  - Added a `DUMMY_USER` to `User` model for testing purposes
  - Factored out a helper function `dpToPixels` and put it in `ActivityHelper`
- Profile preview and editing
  - Updated `ProfileActivity` to support profile editing (previously just for profile preview)
  - Removed "reach me" section in `ProfileFragment` after discussion with design
  - Created basic `TabLayout` + `ViewPager` setup for the profile editing
  - Added an `EditText` for editing name in `EditProfileFragment`
  - Updated `EditInterestsGroupsFragment` to support new designs for editing interests and groups
    - Added a delete icon to interests and groups and modified `UserFieldAdapter` accordingly
  - Created `AddUserFieldActivity` for users to add new interests and groups- this kept the logic in `EditInterestsGroupsFragment` simpler, and can probably be reused for prompts as well
  - Created `UserRepository` to keep track of local changes to user data
    - Currently, only interests and groups are hooked up to the repository
 - Miscellaneous
   - Fixed a bug with pause pear UI

## Test Coverage
Play-tested on Pixel 3 at API 31.

## Next Steps
- Add prompts to profile editing flow 
- Split `UserRepository` into a Repository and a ViewModel- right now, it does the work of both
- Hook up general info and prompts to the ViewModel
- Add networking
- Make sure onboarding is not broken, since I've been modifying some fragments used in onboarding
- Wrap up all TODO statements I've added in this PR
- Remove logic pertaining to interests and groups logic from `ProfileSettingsActivity`- I'm eventually planning to turn this activity into just `SettingsActivity`, since that's what it's going to be used for

## Screenshots & Videos

<!-- If you are making any changes to UI, you should use this section. -->

<details>

  <summary>Screen Recording</summary>


https://user-images.githubusercontent.com/19438967/199169058-c5595476-5949-40dd-96cd-017b242b7223.mp4


  <!-- <img src="LINK" width=num/>  -->
  <!-- You can drag your file to attach it, obtaining the URL.
  

</details>
